### PR TITLE
Add one-click practice red/black opening buttons

### DIFF
--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -45,6 +45,8 @@ class ActionDefinitions {
         case reviewThisGame
         case practiceNewGame
         case focusedPractice
+        case practiceRedOpening
+        case practiceBlackOpening
         case searchCurrentMove
         case importPGN  // 新增：导入PGN按钮
         case autoAddToOpening  // 新增：自动完善开局库

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -225,6 +225,8 @@ class ViewModel: ObservableObject {
 
         actionDefinitions.registerAction(.practiceNewGame, text: "练习新局", textIPhone: "练习", shortcuts: [.single("P")], supportedModes: ActionDefinitions.allModes) { self.practiceNewGame() }
         actionDefinitions.registerAction(.focusedPractice, text: "练习本局", textIPhone: "专练", shortcuts: [.single("Z")], supportedModes: ActionDefinitions.allModes) { self.startFocusedPractice() }
+        actionDefinitions.registerAction(.practiceRedOpening, text: "练习红方开局", supportedModes: ActionDefinitions.allModes) { self.practiceRedOpening() }
+        actionDefinitions.registerAction(.practiceBlackOpening, text: "练习黑方开局", supportedModes: ActionDefinitions.allModes) { self.practiceBlackOpening() }
         actionDefinitions.registerAction(.playRandomNextMove, text: "随机走子", textIPhone: "随机", shortcuts: [.sequence(",r")], supportedModes: [.practice]) { self.playRandomNextMove() }
         actionDefinitions.registerAction(.hintNextMove, text: "提示", textIPhone: "提示", supportedModes: [.practice]) { self.playRandomNextMove() }
 
@@ -1680,6 +1682,50 @@ class ViewModel: ObservableObject {
         sessionManager.startFocusedPractice()
 
         // Auto-play if it's opponent's turn
+        playRandomIfYourTurn(delay: 1.0)
+    }
+
+    func practiceRedOpening() {
+        // 退出 focusedPractice（如果正在进行）
+        if sessionManager.isInFocusedPractice {
+            sessionManager.exitFocusedPractice()
+        }
+
+        // 切换到红方开局范围
+        sessionManager.setFilters([Session.filterRedOpeningOnly])
+
+        // 先跳到起点，再锁定在开始局面
+        session.toStart()
+        if self.isAnyMoveLocked {
+            self.toggleLock()
+        }
+        self.toggleLock()
+        if session.sessionData.currentMode != .practice {
+            session.togglePracticeMode()
+        }
+
+        playRandomIfYourTurn(delay: 1.0)
+    }
+
+    func practiceBlackOpening() {
+        // 退出 focusedPractice（如果正在进行）
+        if sessionManager.isInFocusedPractice {
+            sessionManager.exitFocusedPractice()
+        }
+
+        // 切换到黑方开局范围
+        sessionManager.setFilters([Session.filterBlackOpeningOnly])
+
+        // 先跳到起点，再锁定在开始局面
+        session.toStart()
+        if self.isAnyMoveLocked {
+            self.toggleLock()
+        }
+        self.toggleLock()
+        if session.sessionData.currentMode != .practice {
+            session.togglePracticeMode()
+        }
+
         playRandomIfYourTurn(delay: 1.0)
     }
 

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -18,6 +18,8 @@ struct MacActionButtonsView: View {
             .practiceNewGame,
             .reviewThisGame,
             .focusedPractice,
+            .practiceRedOpening,
+            .practiceBlackOpening,
             .removeMoveFromGame,
         ]
     }

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -206,6 +206,8 @@ struct MacMenuCommands: Commands {
             menuButton(.practiceNewGame)
             menuButton(.reviewThisGame)
             menuButton(.focusedPractice)
+            menuButton(.practiceRedOpening)
+            menuButton(.practiceBlackOpening)
             menuButton(.stepLimitation)
             Divider()
             menuButton(.autoAddToOpening)

--- a/XiangqiNotebook/Views/iOS/iPadActionButtonsView.swift
+++ b/XiangqiNotebook/Views/iOS/iPadActionButtonsView.swift
@@ -16,6 +16,8 @@ struct iPadActionButtonsView: View {
                     LargeButton(viewModel: viewModel, actionKey: .nextVariant)
                     LargeButton(viewModel: viewModel, actionKey: .practiceNewGame)
                     LargeButton(viewModel: viewModel, actionKey: .reviewThisGame)
+                    LargeButton(viewModel: viewModel, actionKey: .practiceRedOpening)
+                    LargeButton(viewModel: viewModel, actionKey: .practiceBlackOpening)
                     LargeButton(viewModel: viewModel, actionKey: .playRandomNextMove)
                     LargeButton(viewModel: viewModel, actionKey: .removeMoveFromGame)
                 }

--- a/XiangqiNotebook/Views/iOS/iPhoneBasicButtonsView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneBasicButtonsView.swift
@@ -27,8 +27,8 @@ struct iPhoneBasicButtonsView: View {
 
             HStack(spacing: 15) {
                 iPhoneButton(viewModel: viewModel, actionKey: .save)
-                iPhoneButton(viewModel: viewModel, actionKey: .showMoreActionsIOS)
-                iPhoneButton(viewModel: viewModel, actionKey: .showMoreActionsIOS)
+                iPhoneButton(viewModel: viewModel, actionKey: .practiceRedOpening)
+                iPhoneButton(viewModel: viewModel, actionKey: .practiceBlackOpening)
                 iPhoneButton(viewModel: viewModel, actionKey: .showMoreActionsIOS)
             }
             .padding(.horizontal)


### PR DESCRIPTION
## Summary
- Add dedicated "练习红方开局" / "练习黑方开局" buttons that combine scope-switching and practice-mode entry into a single action
- Each action: exits focused practice if active → switches opening scope → jumps to start → locks at starting position → enters practice mode → auto-plays opponent's first move
- Buttons added to macOS menu bar, macOS button area, iPad row 1, and iPhone row 3 (replacing duplicate placeholders)

## Test plan
- [ ] macOS: verify buttons appear in button area (row 1, after 练习本局)
- [ ] macOS: verify menu items appear in 操作 menu (after 练习本局)
- [ ] Click "练习红方开局" → should switch to red opening scope, lock at start, enter practice mode
- [ ] Click "练习黑方开局" → should switch to black opening scope, lock at start, enter practice mode, auto-play red's first move
- [ ] iPad/iPhone: verify buttons appear in button layout
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves #3 