### PR TITLE
Fix: 参考棋谱窗口累积显示

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -66,6 +66,10 @@ class ViewModel: ObservableObject {
     @Published var globalAlertTitle = ""
     @Published var globalAlertMessage = ""
 
+    #if os(macOS)
+    private var referenceBoardWindowController: ReferenceBoardWindowController?
+    #endif
+
     // 用于存储订阅
     private var cancellables = Set<AnyCancellable>()
 
@@ -1344,16 +1348,24 @@ class ViewModel: ObservableObject {
     
     func showReferenceBoard() {
         #if os(macOS)
-        let windowController = ReferenceBoardWindowController(
+        let item = ReferenceBoardItem(
             fen: session.currentFen,
             orientation: session.isCurrentBlackOrientation ? "black" : "red",
             isHorizontalFlipped: session.isCurrentHorizontalFlipped,
             showPath: showPath,
             currentFenPathGroups: session.getCurrentFenPathGroups(),
             score: displayScore,
+            scoreDelta: "",
             comments: session.currentCombinedComment ?? ""
         )
-        windowController.showWindow(nil)
+
+        if let controller = referenceBoardWindowController, controller.window?.isVisible == true {
+            controller.update(item)
+        } else {
+            let controller = ReferenceBoardWindowController(item: item)
+            referenceBoardWindowController = controller
+            controller.showWindow(nil)
+        }
         #endif
     }
     

--- a/XiangqiNotebook/Views/Mac/ReferenceBoardWindowController.swift
+++ b/XiangqiNotebook/Views/Mac/ReferenceBoardWindowController.swift
@@ -2,19 +2,39 @@ import SwiftUI
 #if os(macOS)
 import AppKit
 
+struct ReferenceBoardItem: Identifiable {
+    let id = UUID()
+    let fen: String
+    let orientation: String
+    let isHorizontalFlipped: Bool
+    let showPath: Bool
+    let currentFenPathGroups: [PathGroup]
+    let score: String
+    let scoreDelta: String
+    let comments: String
+}
+
+class ReferenceBoardItemsStore: ObservableObject {
+    @Published var items: [ReferenceBoardItem] = []
+
+    func append(_ item: ReferenceBoardItem) {
+        items.append(item)
+    }
+}
+
 struct ReferenceBoardContentView: View {
     let boardViewModel: BoardViewModel
     let score: String
     let scoreDelta: String
     let comments: String
-    
+
     var body: some View {
         VStack(spacing: 10) {
             XiangqiBoard(viewModel: .constant(boardViewModel))
                 .disabled(true)
                 .frame(width: 400, height: 400)
                 .padding()
-            
+
             HStack {
                 Text("分数：\(score)")
                     .font(.system(.body, design: .monospaced))
@@ -25,12 +45,12 @@ struct ReferenceBoardContentView: View {
                     .foregroundColor(Int(scoreDelta) ?? 0 < -100 ? .red : .primary)
             }
             .padding(.horizontal)
-            
+
             ScrollView {
                 Text(comments)
                     .font(.body)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)  // 允许选择文本
+                    .textSelection(.enabled)
             }
             .frame(maxWidth: .infinity)
             .padding()
@@ -41,45 +61,88 @@ struct ReferenceBoardContentView: View {
     }
 }
 
+struct ReferenceBoardGridView: View {
+    @ObservedObject var store: ReferenceBoardItemsStore
+    let columns: [GridItem] = [GridItem(.adaptive(minimum: 400), spacing: 24)]
+    @State private var hiddenItemIds: Set<UUID> = []
+
+    var filteredItems: [ReferenceBoardItem] {
+        store.items.filter { !hiddenItemIds.contains($0.id) }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 32) {
+                ForEach(filteredItems) { item in
+                    ReferenceBoardContentView(
+                        boardViewModel: BoardViewModel(
+                            fen: item.fen,
+                            orientation: item.orientation,
+                            isHorizontalFlipped: item.isHorizontalFlipped,
+                            showPath: item.showPath,
+                            showAllNextMoves: false,
+                            shouldAnimate: false,
+                            currentFenPathGroups: item.currentFenPathGroups
+                        ),
+                        score: item.score,
+                        scoreDelta: item.scoreDelta,
+                        comments: item.comments
+                    )
+                    .frame(width: 400, height: 550)
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(8)
+                    .contextMenu {
+                        Button(action: {
+                            hiddenItemIds.insert(item.id)
+                        }) {
+                            Label("隐藏", systemImage: "eye.slash")
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
 class ReferenceBoardWindowController: NSWindowController {
-    init(fen: String, orientation: String, isHorizontalFlipped: Bool, showPath: Bool, currentFenPathGroups: [PathGroup], score: String = "", scoreDelta: String = "", comments: String = "") {
+    private let store: ReferenceBoardItemsStore
+
+    init(item: ReferenceBoardItem) {
+        let store = ReferenceBoardItemsStore()
+        store.items = [item]
+        self.store = store
+
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 700), // 增加窗口高度以适应更多内容
-            styleMask: [.titled, .closable, .miniaturizable, .resizable], // 添加 .resizable
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 700),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
-        window.title = "参考棋盘"
-        window.minSize = NSSize(width: 400, height: 600) // 设置最小尺寸
-        
-        let boardViewModel = BoardViewModel(
-            fen: fen,
-            orientation: orientation,
-            isHorizontalFlipped: isHorizontalFlipped,
-            showPath: showPath,
-            showAllNextMoves: false,
-            shouldAnimate: false,
-            currentFenPathGroups: currentFenPathGroups
-        )
-        
-        window.contentView = NSHostingView(rootView: ReferenceBoardContentView(
-            boardViewModel: boardViewModel,
-            score: score,
-            scoreDelta: scoreDelta,
-            comments: comments
-        ))
-        
+        window.title = "参考棋盘(1)"
+        window.minSize = NSSize(width: 400, height: 600)
+
+        let gridView = ReferenceBoardGridView(store: store)
+        window.contentView = NSHostingView(rootView: gridView)
+
         window.center()
         super.init(window: window)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    func update(_ item: ReferenceBoardItem) {
+        store.append(item)
+        window?.title = "参考棋盘(\(store.items.count))"
+        window?.makeKeyAndOrderFront(nil)
+    }
+
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
         window?.makeKeyAndOrderFront(nil)
     }
 }
-#endif 
+#endif


### PR DESCRIPTION
## Summary
- 参考棋盘窗口已存在时，Cmd+X 追加新棋谱项目（而非替换）
- 窗口不存在/不可见时，创建新窗口
- 窗口标题显示当前项目数量，如 `参考棋盘(3)`
- 支持右键隐藏单个项目

Closes #4

## Test plan
- [x] 全部单元测试通过，无回归
- [x] macOS 手动测试：Cmd+X 创建窗口（1 项）→ 导航到不同局面 → 再次 Cmd+X → 同一窗口追加（2 项）
- [x] 关闭窗口 → Cmd+X → 创建新窗口（1 项）
- [ ] 右键隐藏单个项目

🤖 Generated with [Claude Code](https://claude.com/claude-code)