### PR TITLE
Fix: improve game stat row spacing

### DIFF
--- a/XiangqiNotebook/Views/StatusBarView.swift
+++ b/XiangqiNotebook/Views/StatusBarView.swift
@@ -29,16 +29,16 @@ struct StatusBarView: View {
     }
     
     private func gameStatRow(_ label: String, total: Int, wins: Int, draws: Int, losses: Int) -> some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 4) {
             Text(label)
             Text("总")
-            Text("\(total)").frame(minWidth: 16, alignment: .leading)
+            Text("\(total)").frame(minWidth: 24, alignment: .leading)
             Text("胜")
-            Text("\(wins)").frame(minWidth: 16, alignment: .leading)
+            Text("\(wins)").frame(minWidth: 24, alignment: .leading)
             Text("和")
-            Text("\(draws)").frame(minWidth: 16, alignment: .leading)
+            Text("\(draws)").frame(minWidth: 24, alignment: .leading)
             Text("负")
-            Text("\(losses)").frame(minWidth: 16, alignment: .leading)
+            Text("\(losses)").frame(minWidth: 24, alignment: .leading)
         }
         .font(fontStyle)
     }

--- a/XiangqiNotebook/Views/iOS/iPhoneStatusBarView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneStatusBarView.swift
@@ -21,16 +21,16 @@ struct iPhoneStatusBarView: View {
     }
     
     private func gameStatRow(_ label: String, total: Int, wins: Int, draws: Int, losses: Int) -> some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 4) {
             Text(label)
             Text("总")
-            Text("\(total)").frame(minWidth: 14, alignment: .leading)
+            Text("\(total)").frame(minWidth: 20, alignment: .leading)
             Text("胜")
-            Text("\(wins)").frame(minWidth: 14, alignment: .leading)
+            Text("\(wins)").frame(minWidth: 20, alignment: .leading)
             Text("和")
-            Text("\(draws)").frame(minWidth: 14, alignment: .leading)
+            Text("\(draws)").frame(minWidth: 20, alignment: .leading)
             Text("负")
-            Text("\(losses)").frame(minWidth: 14, alignment: .leading)
+            Text("\(losses)").frame(minWidth: 20, alignment: .leading)
         }
         .font(fontStyle)
     }


### PR DESCRIPTION
## Summary
- Increase `HStack` spacing from 2 to 4 in `gameStatRow()` for both Mac/iPad and iPhone
- Increase number `minWidth` from 16→24 (Mac/iPad) and 14→20 (iPhone) for consistent alignment

Previously numbers and labels were crammed together, making stats like "总569胜343和16负207" hard to read.

Closes #8

## Test plan
- [x] Unit tests pass
- [x] Visually verify spacing on Mac
- [ ] Visually verify spacing on iPhone

🤖 Generated with [Claude Code](https://claude.com/claude-code)