### PR TITLE
Move lock logic to DatabaseView & UI toggle to filter group

### DIFF
--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -693,6 +693,21 @@ final class DatabaseView {
         )
     }
 
+    /// 锁定视图：在已有视图基础上叠加 reachable fenId 过滤
+    /// - Parameters:
+    ///   - base: 基础 DatabaseView（scope 过滤）
+    ///   - reachableFenIds: BFS 计算出的可达 fenId 集合
+    static func withLock(_ base: DatabaseView, reachableFenIds: Set<Int>) -> DatabaseView {
+        return DatabaseView(
+            database: base.database,
+            fenIdFilter: { fenId in
+                base.fenIdFilter(fenId) && reachableFenIds.contains(fenId)
+            },
+            moveIdFilter: base.moveIdFilter,
+            gameIdFilter: base.gameIdFilter
+        )
+    }
+
     /// 组合筛选视图 - 支持多个 filter 的 AND 组合
     /// - Parameters:
     ///   - database: 数据库实例

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1516,6 +1516,7 @@ class ViewModel: ObservableObject {
     var currentFenPracticeCount: Int { session.currentFenPracticeCount }
     var autoExtendGameWhenPlayingBoardFen: Bool { session.autoExtendGameWhenPlayingBoardFen }
     var gameStepLimitation: Int? { session.gameStepLimitation }
+    var currentLockedStep: Int? { session.sessionData.lockedStep }
     func setGameStepLimitation(_ limit: Int?) { session.setGameStepLimitation(limit) }
 
     func isBadMove(_ move: Move) -> Bool { session.isBadMove(move) }

--- a/XiangqiNotebook/Views/TogglesView.swift
+++ b/XiangqiNotebook/Views/TogglesView.swift
@@ -19,10 +19,11 @@ struct TogglesView: View {
                 MyToggle(viewModel: viewModel, actionKey: .toggleFilterSpecificGame)
                 MyToggle(viewModel: viewModel, actionKey: .toggleFilterSpecificBook)
                 MyToggle(viewModel: viewModel, actionKey: .toggleStepLimitation)
+                MyToggle(viewModel: viewModel, actionKey: .toggleLock)
             }
             .padding(8) // 添加内边距，让内容不贴边
             .border(Color.gray)
-            
+
             // 开局库设置区域
             VStack(alignment: .leading) {
                 MyToggle(viewModel: viewModel, actionKey: .inRedOpening)
@@ -31,10 +32,8 @@ struct TogglesView: View {
             }
             .padding(8) // 添加内边距，让内容不贴边
             .border(Color.gray)
-            
-            // 开局库设置区域
+
             VStack(alignment: .leading) {
-                MyToggle(viewModel: viewModel, actionKey: .toggleLock)
                 MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
             }
             .padding(8) // 添加内边距，让内容不贴边
@@ -83,6 +82,9 @@ struct MyToggle: View {
         } else if actionKey == .toggleStepLimitation,
                   let limit = viewModel.gameStepLimitation {
             text += ": \(limit)"
+        } else if actionKey == .toggleLock,
+                  let lockedStep = viewModel.currentLockedStep {
+            text += ": \(lockedStep)"
         }
 
         if let displayText = toggleActionInfo.shortcutsDisplayText {


### PR DESCRIPTION
## Summary
- Add `DatabaseView.withLock()` factory method that filters to BFS-reachable positions from the locked step
- Update `Session.rebuildDatabaseView()` to handle lock-only case (no step limit active)
- Ensure `rebuildDatabaseView()` is called everywhere `lockedStep` changes: `toggleLock()`, `playNewGame()`, `resetGameStateForDatabaseRestore()`, `loadGame()`, `loadBook()`
- Move `.toggleLock` into the "棋局筛选" section in TogglesView (after `.toggleStepLimitation`)
- Display locked step value on the lock toggle label (e.g. "锁定: 5")
- Expose `currentLockedStep` from ViewModel

Closes #14

## Test plan
- [x] Run full test suite — all tests pass
- [x] Verify lock toggle appears in the "棋局筛选" section (after step limitation)
- [x] Verify `.toggleCanNavigateBeforeLockedStep` remains in its own section
- [x] Verify locking restricts DatabaseView to reachable positions (path exploration limited)
- [x] Verify unlocking restores full DatabaseView scope
- [x] Verify lock toggle displays the locked step number when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)