### PR TITLE
将锁定区域前进后退 toggle 移入自动延拓群组

### DIFF
--- a/XiangqiNotebook/Views/TogglesView.swift
+++ b/XiangqiNotebook/Views/TogglesView.swift
@@ -33,17 +33,12 @@ struct TogglesView: View {
             .padding(8) // 添加内边距，让内容不贴边
             .border(Color.gray)
 
-            VStack(alignment: .leading) {
-                MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
-            }
-            .padding(8) // 添加内边距，让内容不贴边
-            .border(Color.gray)
-
             // 棋盘操作
             VStack(alignment: .leading) {
                 MyToggle(viewModel: viewModel, actionKey: .flip)
                 MyToggle(viewModel: viewModel, actionKey: .flipHorizontal)
                 MyToggle(viewModel: viewModel, actionKey: .toggleAutoExtendGameWhenPlayingBoardFen)
+                MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
                 MyToggle(viewModel: viewModel, actionKey: .toggleShowPath)
                 MyToggle(viewModel: viewModel, actionKey: .toggleShowAllNextMoves)
                 MyToggle(viewModel: viewModel, actionKey: .togglePracticeMode)


### PR DESCRIPTION
将 `toggleCanNavigateBeforeLockedStep` 从独立 VStack 区域移至棋盘操作群组中，置于 `toggleAutoExtendGameWhenPlayingBoardFen` 之后，使界面布局更加整齐、功能分组更合理。

Fixes #20

Generated with [Claude Code](https://claude.ai/code)