### PR TITLE
重组菜单栏结构，精简按钮界面

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,3 +133,7 @@ xcodebuild test -project XiangqiNotebook.xcodeproj -scheme XiangqiNotebook -dest
 # 运行单个测试方法
 xcodebuild test -project XiangqiNotebook.xcodeproj -scheme XiangqiNotebook -destination 'platform=macOS' -only-testing:XiangqiNotebookTests/TestClassName/testMethodName
 ```
+
+## Git 提交禁止事项
+
+- **禁止提交 `DEVELOPMENT_TEAM`**: 绝不能将 `DEVELOPMENT_TEAM` 设置提交到 git。如果 `project.pbxproj` 中出现 `DEVELOPMENT_TEAM` 的改动，必须在提交前 revert 该行。

--- a/XiangqiNotebook.xcodeproj/project.pbxproj
+++ b/XiangqiNotebook.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				"zh-Hans",
 				Base,
 			);
 			mainGroup = 179BE3EA2D46691E000FA5AC;

--- a/XiangqiNotebook/Resources/zh-Hans.lproj/Localizable.strings
+++ b/XiangqiNotebook/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+/* Chinese (Simplified) localization - enables system menu Chinese names */

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -6,6 +6,10 @@ import AppKit
 struct MacActionButtonsView: View {
     @ObservedObject var viewModel: ViewModel
 
+    private var isPractice: Bool {
+        viewModel.currentAppMode == .practice
+    }
+
     /// 第一行按钮定义
     private var row1Keys: [ActionDefinitions.ActionKey?] {
         [
@@ -14,45 +18,31 @@ struct MacActionButtonsView: View {
             .stepForward,
             .toEnd,
             .nextVariant,
-            (viewModel.currentAppMode == .practice && viewModel.isMyTurn) ? .hintNextMove : .playRandomNextMove,
+            (isPractice && viewModel.isMyTurn) ? .hintNextMove : .playRandomNextMove,
+            .random,
             .practiceNewGame,
             .reviewThisGame,
             .focusedPractice,
-            .practiceRedOpening,
-            .practiceBlackOpening,
-            .removeMoveFromGame,
+            isPractice ? nil : .practiceRedOpening,
+            isPractice ? nil : .practiceBlackOpening,
+            isPractice ? .save : nil,
         ]
     }
 
-    /// 第二行按钮定义
-    private let row2Keys: [ActionDefinitions.ActionKey?] = [
-        .queryScore,
-        .queryEngineScore,
-        .queryAllEngineScores,
-        .openYunku,
-        .fix,
-        .markPath,
-        .referenceBoard,
-        .previousPath,
-        .nextPath,
-        .random,
-        .jumpToNextOpeningGap,
-        .autoAddToOpening,
-    ]
-
-    /// 第三行按钮定义
-    private let row3Keys: [ActionDefinitions.ActionKey?] = [
-        .checkDataVersion,
-        .save,
-        .backup,
-        .restore,
-        .deleteMove,
-        .deleteScore,
-        .inputGame,
-        .browseGames,
-        .importPGN,
-        .searchCurrentMove,
-    ]
+    /// 第二行按钮定义（仅普通模式可见）
+    private var row2Keys: [ActionDefinitions.ActionKey?] {
+        [
+            .queryScore,
+            .queryEngineScore,
+            .queryAllEngineScores,
+            .openYunku,
+            .markPath,
+            .referenceBoard,
+            .browseGames,
+            .importPGN,
+            isPractice ? nil : .save,
+        ]
+    }
 
     /// 检查按钮是否可见
     private func isVisible(_ key: ActionDefinitions.ActionKey?) -> Bool {
@@ -70,7 +60,7 @@ struct MacActionButtonsView: View {
 
     /// 最大可见按钮数量
     private var maxVisibleCount: Int {
-        max(visibleKeys(for: row1Keys).count, visibleKeys(for: row2Keys).count, visibleKeys(for: row3Keys).count)
+        max(visibleKeys(for: row1Keys).count, visibleKeys(for: row2Keys).count)
     }
 
     /// 渲染一行按钮
@@ -96,8 +86,9 @@ struct MacActionButtonsView: View {
     var body: some View {
         VStack(alignment: .leading) {
             buttonRow(keys: row1Keys)
-            buttonRow(keys: row2Keys)
-            buttonRow(keys: row3Keys)
+            if !visibleKeys(for: row2Keys).isEmpty {
+                buttonRow(keys: row2Keys)
+            }
         }
         .padding(8)
         .border(Color.gray)

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -178,53 +178,31 @@ struct MacMenuCommands: Commands {
     @FocusedObject private var viewModel: ViewModel?
 
     var body: some Commands {
-        CommandMenu("操作") {
-            menuButton(.toStart)
-            menuButton(.stepBack)
-            menuButton(.stepForward)
-            menuButton(.toEnd)
+        // 文件 menu
+        CommandGroup(after: .saveItem) {
             Divider()
-            menuButton(.nextVariant)
-            menuButton(.previousPath)
-            menuButton(.nextPath)
+            menuButton(.save)
+            Divider()
+            menuButton(.backup)
+            menuButton(.restore)
+            Divider()
+            menuButton(.checkDataVersion)
+            menuButton(.importPGN)
+            menuButton(.inputGame)
+            menuButton(.browseGames)
+        }
+
+        // 编辑 menu
+        CommandGroup(after: .undoRedo) {
             Divider()
             menuButton(.deleteMove)
             menuButton(.removeMoveFromGame)
             menuButton(.deleteScore)
             Divider()
-            menuButton(.queryScore)
-            menuButton(.queryEngineScore)
-            menuButton(.queryAllEngineScores)
-            Divider()
-            menuButton(.markPath)
-            menuButton(.referenceBoard)
-            menuButton(.openYunku)
-            menuButton(.searchCurrentMove)
-            Divider()
-            menuButton(.playRandomNextMove)
-            menuButton(.hintNextMove)
-            menuButton(.practiceNewGame)
-            menuButton(.reviewThisGame)
-            menuButton(.focusedPractice)
-            menuButton(.practiceRedOpening)
-            menuButton(.practiceBlackOpening)
-            menuButton(.stepLimitation)
-            Divider()
-            menuButton(.autoAddToOpening)
-            menuButton(.jumpToNextOpeningGap)
-            Divider()
-            menuButton(.save)
-            menuButton(.backup)
-            menuButton(.restore)
-            menuButton(.checkDataVersion)
-            menuButton(.importPGN)
-            menuButton(.inputGame)
-            menuButton(.browseGames)
-            Divider()
             menuButton(.fix)
-            menuButton(.random)
         }
 
+        // 显示 menu
         CommandGroup(after: .toolbar) {
             Divider()
             menuToggle(.flip)
@@ -233,18 +211,17 @@ struct MacMenuCommands: Commands {
             menuToggle(.toggleShowPath)
             menuToggle(.toggleShowAllNextMoves)
             Divider()
-            menuToggle(.togglePracticeMode)
-            menuToggle(.toggleLock)
-            menuToggle(.toggleCanNavigateBeforeLockedStep)
-            Divider()
             menuToggle(.toggleIsCommentEditing)
             menuToggle(.toggleAllowAddingNewMoves)
             menuToggle(.toggleAutoExtendGameWhenPlayingBoardFen)
             Divider()
-            menuToggle(.toggleBookmark)
-            menuToggle(.inRedOpening)
-            menuToggle(.inBlackOpening)
-            Divider()
+            menuToggle(.togglePracticeMode)
+            menuToggle(.toggleLock)
+            menuToggle(.toggleCanNavigateBeforeLockedStep)
+        }
+
+        // 筛选 menu
+        CommandMenu("筛选") {
             menuToggle(.setFilterNone)
             Divider()
             menuToggle(.toggleFilterRedOpeningOnly)
@@ -255,6 +232,55 @@ struct MacMenuCommands: Commands {
             menuToggle(.setFilterFocusedPractice)
             menuToggle(.toggleFilterSpecificGame)
             menuToggle(.toggleFilterSpecificBook)
+            Divider()
+            menuButton(.stepLimitation)
+            Divider()
+            menuToggle(.toggleBookmark)
+            menuToggle(.inRedOpening)
+            menuToggle(.inBlackOpening)
+        }
+
+        // 导航 menu
+        CommandMenu("导航") {
+            menuButton(.toStart)
+            menuButton(.stepBack)
+            menuButton(.stepForward)
+            menuButton(.toEnd)
+            Divider()
+            menuButton(.nextVariant)
+            menuButton(.previousPath)
+            menuButton(.nextPath)
+            Divider()
+            menuButton(.random)
+        }
+
+        // 分析 menu
+        CommandMenu("分析") {
+            menuButton(.queryScore)
+            menuButton(.queryEngineScore)
+            menuButton(.queryAllEngineScores)
+            Divider()
+            menuButton(.referenceBoard)
+            menuButton(.openYunku)
+            menuButton(.searchCurrentMove)
+            Divider()
+            menuButton(.markPath)
+            Divider()
+            menuButton(.autoAddToOpening)
+            menuButton(.jumpToNextOpeningGap)
+        }
+
+        // 练习 menu
+        CommandMenu("练习") {
+            menuButton(.playRandomNextMove)
+            menuButton(.hintNextMove)
+            Divider()
+            menuButton(.practiceNewGame)
+            menuButton(.reviewThisGame)
+            menuButton(.focusedPractice)
+            Divider()
+            menuButton(.practiceRedOpening)
+            menuButton(.practiceBlackOpening)
         }
     }
 


### PR DESCRIPTION
## Summary
- 将单一"操作"菜单拆分为文件、编辑、显示、筛选、导航、分析、练习七个逻辑分组
- 按钮面板从三行精简为常规模式两行、练习模式一行（模式自适应）
- 添加简体中文本地化支持，使 macOS 系统菜单（文件、编辑、显示等）正确显示中文

Closes #15

## Test plan
- [x] 全部单元测试通过
- [x] 验证菜单栏七个分组结构和内容正确
- [x] 验证常规模式显示两行按钮、练习模式显示一行按钮
- [x] 验证键盘快捷键仍正常工作
- [ ] 验证 iOS/iPad 界面不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)