### PR TITLE
添加 SRSData 数据模型与 SM-2 间隔复习算法

### DIFF
--- a/XiangqiNotebook/Models/DatabaseData.swift
+++ b/XiangqiNotebook/Models/DatabaseData.swift
@@ -8,6 +8,7 @@ class DatabaseData: Codable {
     var gameObjects: [UUID: GameObject] = [:]
     var bookObjects: [UUID: BookObject] = [:]
     var bookmarks: [[Int]: String] = [:]
+    var reviewItems: [Int: SRSData] = [:]
     var myRealRedGameStatisticsByFenId: [Int: GameResultStatistics] = [:]
     var myRealBlackGameStatisticsByFenId: [Int: GameResultStatistics] = [:]
     var dataVersion: Int = 0
@@ -18,6 +19,7 @@ class DatabaseData: Codable {
         case gameObjects = "game_objects"
         case bookObjects = "book_objects"
         case bookmarks
+        case reviewItems = "review_items"
         case myRealRedGameStatisticsByFenId = "my_real_red_game_statistics_by_fen_id"
         case myRealBlackGameStatisticsByFenId = "my_real_black_game_statistics_by_fen_id"
         case dataVersion = "data_version"
@@ -39,6 +41,7 @@ class DatabaseData: Codable {
         gameObjects = try container.decode([UUID: GameObject].self, forKey: .gameObjects)
         bookObjects = try container.decode([UUID: BookObject].self, forKey: .bookObjects)
         bookmarks = try container.decode([[Int]: String].self, forKey: .bookmarks)
+        reviewItems = try container.decodeIfPresent([Int: SRSData].self, forKey: .reviewItems) ?? [:]
         myRealRedGameStatisticsByFenId = try container.decode([Int: GameResultStatistics].self, forKey: .myRealRedGameStatisticsByFenId)
         myRealBlackGameStatisticsByFenId = try container.decode([Int: GameResultStatistics].self, forKey: .myRealBlackGameStatisticsByFenId)
         dataVersion = try container.decode(Int.self, forKey: .dataVersion)

--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -170,6 +170,10 @@ final class DatabaseView {
         database.databaseData.bookmarks
     }
 
+    var reviewItems: [Int: SRSData] {
+        database.databaseData.reviewItems
+    }
+
     var dataVersion: Int {
         database.databaseData.dataVersion
     }
@@ -467,6 +471,12 @@ final class DatabaseView {
             database.databaseData.fenToId[fenObject.fen] = fenId
             markDirty()
         }
+    }
+
+    /// 更新复习项（nil 表示删除）
+    func updateReviewItem(for fenId: Int, srsData: SRSData?) {
+        database.databaseData.reviewItems[fenId] = srsData
+        markDirty()
     }
 
     /// 更新 bookmarks

--- a/XiangqiNotebook/Models/SRSData.swift
+++ b/XiangqiNotebook/Models/SRSData.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// 间隔复习算法数据（Spaced Repetition System）
+/// 每个复习项对应一个局面（fenId），存储在 DatabaseData.reviewItems 中
+class SRSData: Codable {
+    var gamePath: [Int]?
+    var easeFactor: Double = 2.5
+    var interval: Int = 0
+    var repetitions: Int = 0
+    var nextReviewDate: Date
+    var lastReviewDate: Date?
+
+    init(gamePath: [Int]? = nil, nextReviewDate: Date = Date()) {
+        self.gamePath = gamePath
+        self.nextReviewDate = nextReviewDate
+    }
+
+    /// 是否到期需要复习
+    var isDue: Bool {
+        return nextReviewDate <= Date()
+    }
+
+    /// SM-2 算法：根据自评等级更新间隔复习参数
+    /// - Parameter quality: 自评等级
+    ///   - .again (1): 完全不会，重置间隔
+    ///   - .hard (2): 需要加强，重置间隔
+    ///   - .good (4): 基本掌握，按间隔增长
+    ///   - .easy (5): 完全掌握，按间隔增长
+    func review(quality: ReviewQuality) {
+        let q = quality.rawValue
+
+        // 更新 easeFactor
+        let newEF = easeFactor + (0.1 - Double(5 - q) * (0.08 + Double(5 - q) * 0.02))
+        easeFactor = max(1.3, newEF)
+
+        if q < 3 {
+            // 失败：重置
+            repetitions = 0
+            interval = 0
+        } else {
+            // 成功：增长间隔
+            repetitions += 1
+            switch repetitions {
+            case 1:
+                interval = 1
+            case 2:
+                interval = 6
+            default:
+                interval = Int(round(Double(interval) * easeFactor))
+            }
+        }
+
+        lastReviewDate = Date()
+        nextReviewDate = Calendar.current.date(byAdding: .day, value: max(interval, 1), to: lastReviewDate!)!
+    }
+}
+
+/// 复习自评等级
+enum ReviewQuality: Int, Codable {
+    case again = 1
+    case hard = 2
+    case good = 4
+    case easy = 5
+}

--- a/XiangqiNotebookTests/SRSDataTests.swift
+++ b/XiangqiNotebookTests/SRSDataTests.swift
@@ -1,0 +1,238 @@
+import Testing
+import Foundation
+@testable import XiangqiNotebook
+
+struct SRSDataTests {
+
+    // MARK: - Initialization
+
+    @Test func testDefaultInitialization() {
+        let srs = SRSData()
+        #expect(srs.easeFactor == 2.5)
+        #expect(srs.interval == 0)
+        #expect(srs.repetitions == 0)
+        #expect(srs.lastReviewDate == nil)
+        #expect(srs.gamePath == nil)
+    }
+
+    @Test func testInitializationWithGamePath() {
+        let path = [1, 2, 3]
+        let srs = SRSData(gamePath: path)
+        #expect(srs.gamePath == path)
+    }
+
+    // MARK: - SM-2 Algorithm: Failed Reviews
+
+    @Test func testReviewAgainResetsInterval() {
+        let srs = SRSData()
+        srs.repetitions = 3
+        srs.interval = 15
+        srs.review(quality: .again)
+
+        #expect(srs.repetitions == 0)
+        #expect(srs.interval == 0)
+        #expect(srs.lastReviewDate != nil)
+    }
+
+    @Test func testReviewHardResetsInterval() {
+        let srs = SRSData()
+        srs.repetitions = 3
+        srs.interval = 15
+        srs.review(quality: .hard)
+
+        #expect(srs.repetitions == 0)
+        #expect(srs.interval == 0)
+    }
+
+    // MARK: - SM-2 Algorithm: Successful Reviews
+
+    @Test func testFirstSuccessfulReviewSetsInterval1() {
+        let srs = SRSData()
+        srs.review(quality: .good)
+
+        #expect(srs.repetitions == 1)
+        #expect(srs.interval == 1)
+    }
+
+    @Test func testSecondSuccessfulReviewSetsInterval6() {
+        let srs = SRSData()
+        srs.review(quality: .good)
+        srs.review(quality: .good)
+
+        #expect(srs.repetitions == 2)
+        #expect(srs.interval == 6)
+    }
+
+    @Test func testThirdSuccessfulReviewUsesEaseFactor() {
+        let srs = SRSData()
+        srs.review(quality: .easy)
+        srs.review(quality: .easy)
+        srs.review(quality: .easy)
+
+        #expect(srs.repetitions == 3)
+        // interval = round(6 * easeFactor)
+        // easeFactor after 3 easy reviews increases from 2.5
+        #expect(srs.interval > 6)
+    }
+
+    // MARK: - SM-2 Algorithm: Ease Factor
+
+    @Test func testEaseFactorIncreasesWithEasyReviews() {
+        let srs = SRSData()
+        let initialEF = srs.easeFactor
+        srs.review(quality: .easy)
+        #expect(srs.easeFactor > initialEF)
+    }
+
+    @Test func testEaseFactorDecreasesWithAgainReviews() {
+        let srs = SRSData()
+        let initialEF = srs.easeFactor
+        srs.review(quality: .again)
+        #expect(srs.easeFactor < initialEF)
+    }
+
+    @Test func testEaseFactorNeverBelowMinimum() {
+        let srs = SRSData()
+        // Repeatedly fail to push easeFactor down
+        for _ in 0..<20 {
+            srs.review(quality: .again)
+        }
+        #expect(srs.easeFactor >= 1.3)
+    }
+
+    // MARK: - SM-2 Algorithm: Next Review Date
+
+    @Test func testNextReviewDateAdvancesAfterReview() {
+        let srs = SRSData(nextReviewDate: Date())
+        let before = srs.nextReviewDate
+        srs.review(quality: .good)
+        #expect(srs.nextReviewDate > before)
+    }
+
+    @Test func testNextReviewDateAfterFailIsOneDayLater() {
+        let srs = SRSData()
+        srs.review(quality: .again)
+        // interval is 0, but nextReviewDate uses max(interval, 1) = 1 day
+        let expectedDate = Calendar.current.date(byAdding: .day, value: 1, to: srs.lastReviewDate!)!
+        let diff = abs(srs.nextReviewDate.timeIntervalSince(expectedDate))
+        #expect(diff < 1.0) // within 1 second tolerance
+    }
+
+    // MARK: - SM-2 Algorithm: Reset After Failure
+
+    @Test func testResetAfterFailureThenRecover() {
+        let srs = SRSData()
+        // Build up progress
+        srs.review(quality: .good) // rep 1, interval 1
+        srs.review(quality: .good) // rep 2, interval 6
+        srs.review(quality: .good) // rep 3, interval > 6
+
+        // Fail
+        srs.review(quality: .again)
+        #expect(srs.repetitions == 0)
+        #expect(srs.interval == 0)
+
+        // Recover
+        srs.review(quality: .good) // rep 1, interval 1
+        #expect(srs.repetitions == 1)
+        #expect(srs.interval == 1)
+    }
+
+    // MARK: - isDue
+
+    @Test func testIsDueWhenPastNextReviewDate() {
+        let srs = SRSData(nextReviewDate: Date().addingTimeInterval(-3600))
+        #expect(srs.isDue == true)
+    }
+
+    @Test func testIsNotDueWhenBeforeNextReviewDate() {
+        let srs = SRSData(nextReviewDate: Date().addingTimeInterval(3600))
+        #expect(srs.isDue == false)
+    }
+
+    // MARK: - Codable
+
+    @Test func testEncodeDecode() throws {
+        let srs = SRSData(gamePath: [1, 2, 3])
+        srs.easeFactor = 2.3
+        srs.interval = 6
+        srs.repetitions = 2
+        srs.lastReviewDate = Date()
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(srs)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(SRSData.self, from: data)
+
+        #expect(decoded.gamePath == [1, 2, 3])
+        #expect(decoded.easeFactor == 2.3)
+        #expect(decoded.interval == 6)
+        #expect(decoded.repetitions == 2)
+        #expect(decoded.lastReviewDate != nil)
+    }
+
+    @Test func testEncodeDecodeWithNilGamePath() throws {
+        let srs = SRSData()
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(srs)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(SRSData.self, from: data)
+
+        #expect(decoded.gamePath == nil)
+        #expect(decoded.easeFactor == 2.5)
+    }
+
+    // MARK: - DatabaseData Integration
+
+    @Test func testDatabaseDataReviewItemsDefault() {
+        let db = DatabaseData()
+        #expect(db.reviewItems.isEmpty)
+    }
+
+    @Test func testDatabaseDataReviewItemsSerialization() throws {
+        let db = DatabaseData()
+        let srs = SRSData(gamePath: [1, 2])
+        db.reviewItems[42] = srs
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(db)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(DatabaseData.self, from: data)
+
+        #expect(decoded.reviewItems.count == 1)
+        #expect(decoded.reviewItems[42]?.gamePath == [1, 2])
+    }
+
+    @Test func testDatabaseDataBackwardCompatibility() throws {
+        // Simulate old data without reviewItems field
+        // Note: [UUID: X] dictionaries encode as JSON arrays, not objects
+        let json = """
+        {
+            "fenObjects2": {},
+            "MoveObjects": {},
+            "game_objects": [],
+            "book_objects": [],
+            "bookmarks": [],
+            "my_real_red_game_statistics_by_fen_id": {},
+            "my_real_black_game_statistics_by_fen_id": {},
+            "data_version": 1
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let db = try decoder.decode(DatabaseData.self, from: data)
+
+        #expect(db.reviewItems.isEmpty)
+        #expect(db.dataVersion == 1)
+    }
+
+    // MARK: - ReviewQuality
+
+    @Test func testReviewQualityRawValues() {
+        #expect(ReviewQuality.again.rawValue == 1)
+        #expect(ReviewQuality.hard.rawValue == 2)
+        #expect(ReviewQuality.good.rawValue == 4)
+        #expect(ReviewQuality.easy.rawValue == 5)
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `SRSData` 模型，实现 SM-2 间隔复习算法（easeFactor、interval、repetitions、nextReviewDate）
- 支持 4 级自评：完全不会(1)、需要加强(2)、基本掌握(4)、完全掌握(5)
- `DatabaseData` 添加 `reviewItems: [Int: SRSData]`，以 fenId 为 key，`decodeIfPresent` 向后兼容
- `DatabaseView` 添加 `reviewItems` 透传属性和 `updateReviewItem` 方法

Closes #30

## Test plan
- [x] SM-2 算法正确性：成功/失败时的间隔计算、easeFactor 动态调整、最低值限制
- [x] SRSData 序列化/反序列化（含 nil gamePath）
- [x] DatabaseData 集成：reviewItems 默认为空、序列化往返
- [x] 向后兼容：旧数据无 review_items 字段时正常解码
- [x] ReviewQuality 枚举 rawValue 验证
- [x] 全部 21 个单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)