### PR TITLE
实现复习模式与 SM-2 复习流程

### DIFF
--- a/XiangqiNotebook/Models/AppMode.swift
+++ b/XiangqiNotebook/Models/AppMode.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// 应用模式枚举
-/// 定义象棋笔记软件的两种工作模式，每种模式有各自的可见控件
+/// 定义象棋笔记软件的三种工作模式，每种模式有各自的可见控件
 enum AppMode: String, CaseIterable, Codable {
     /// 常规模式 - 完整功能模式，显示所有控件
     case normal = "normal"
@@ -9,23 +9,30 @@ enum AppMode: String, CaseIterable, Codable {
     /// 练习模式 - 专注于练习功能，界面简洁
     case practice = "practice"
 
+    /// 复习模式 - 间隔复习流程
+    case review = "review"
+
     /// 模式的显示名称
     var displayName: String {
         switch self {
-        case .practice:
-            return "练习模式"
         case .normal:
             return "常规模式"
+        case .practice:
+            return "练习模式"
+        case .review:
+            return "复习模式"
         }
     }
 
     /// 模式的描述信息
     var description: String {
         switch self {
-        case .practice:
-            return "专注于练习功能，界面简洁，隐藏非核心控件"
         case .normal:
             return "完整功能模式，显示所有可用控件"
+        case .practice:
+            return "专注于练习功能，界面简洁，隐藏非核心控件"
+        case .review:
+            return "间隔复习模式，按到期顺序复习局面"
         }
     }
 }

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -10,6 +10,10 @@ struct MacActionButtonsView: View {
         viewModel.currentAppMode == .practice
     }
 
+    private var isNormal: Bool {
+        viewModel.currentAppMode == .normal
+    }
+
     /// 第一行按钮定义
     private var row1Keys: [ActionDefinitions.ActionKey?] {
         [
@@ -23,9 +27,9 @@ struct MacActionButtonsView: View {
             .practiceNewGame,
             .reviewThisGame,
             .focusedPractice,
-            isPractice ? nil : .practiceRedOpening,
-            isPractice ? nil : .practiceBlackOpening,
-            isPractice ? .save : nil,
+            isNormal ? .practiceRedOpening : nil,
+            isNormal ? .practiceBlackOpening : nil,
+            !isNormal ? .save : nil,
         ]
     }
 
@@ -40,7 +44,7 @@ struct MacActionButtonsView: View {
             .referenceBoard,
             .browseGames,
             .importPGN,
-            isPractice ? nil : .save,
+            isNormal ? .save : nil,
         ]
     }
 

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -51,20 +51,31 @@ struct MacContentView: View {
                     }
                     .frame(width: geometry.size.width * 0.2)
 
-                    // 右侧区域：着法列表 - 添加 ScrollView 使内容可滚动
-                    ScrollView {
+                    // 右侧区域
+                    if viewModel.isInReviewMode {
+                        // 复习模式：复习面板 + 复习库列表（填满） + 棋盘操作（底部）
                         VStack(spacing: 0) {
-                            // 模式选择器
                             ModeSelectorView(viewModel: viewModel)
-
-                            // 棋局筛选
-                            TogglesView(viewModel: viewModel)
-
-                            // 书签区域
-                            BookmarkListView(viewModel: viewModel)
+                            ReviewModeView(viewModel: viewModel)
+                            ScrollView {
+                                ReviewListView(viewModel: viewModel)
+                            }
+                            .border(Color.gray)
+                            .frame(maxHeight: .infinity)
+                            BoardOperationTogglesView(viewModel: viewModel)
                         }
+                        .frame(width: geometry.size.width * 0.2)
+                    } else {
+                        // 常规/练习模式：ScrollView 包裹
+                        ScrollView {
+                            VStack(spacing: 0) {
+                                ModeSelectorView(viewModel: viewModel)
+                                TogglesView(viewModel: viewModel)
+                                BookmarkListView(viewModel: viewModel)
+                            }
+                        }
+                        .frame(width: geometry.size.width * 0.2)
                     }
-                    .frame(width: geometry.size.width * 0.2)
                 }
 
                 // 按钮区 - 占据所有宽度

--- a/XiangqiNotebook/Views/ReviewListView.swift
+++ b/XiangqiNotebook/Views/ReviewListView.swift
@@ -53,7 +53,6 @@ struct ReviewListView: View {
             }
         }
         .padding(8)
-        .border(Color.gray)
     }
 
     private func dueStatusText(_ srsData: SRSData) -> String {

--- a/XiangqiNotebook/Views/ReviewModeView.swift
+++ b/XiangqiNotebook/Views/ReviewModeView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+/// 复习模式面板（macOS/iPad 共用）
+/// 在复习模式下替换右侧栏的棋局筛选区域
+struct ReviewModeView: View {
+    @ObservedObject var viewModel: ViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if viewModel.isReviewingInProgress {
+                reviewInProgressView
+            } else if viewModel.isReviewComplete {
+                reviewCompleteView
+            } else {
+                noDueItemsView
+            }
+        }
+        .padding(8)
+        .border(Color.gray)
+    }
+
+    // MARK: - 复习进行中
+
+    private var reviewInProgressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("复习中")
+                    .font(.headline)
+                Spacer()
+                Button("退出") {
+                    viewModel.exitReviewMode()
+                }
+                .buttonStyle(.borderless)
+            }
+
+            // 当前复习项描述
+            let item = viewModel.reviewQueue[viewModel.currentReviewIndex]
+            Text(viewModel.reviewItemDescription(fenId: item.fenId))
+                .lineLimit(2)
+                .foregroundColor(.secondary)
+
+            // 进度
+            Text("进度: \(viewModel.reviewProgress)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            // 自评按钮
+            HStack(spacing: 6) {
+                reviewButton("忘了", quality: .again, color: .red)
+                reviewButton("困难", quality: .hard, color: .orange)
+                reviewButton("良好", quality: .good, color: .blue)
+                reviewButton("简单", quality: .easy, color: .green)
+            }
+
+            // 跳过按钮
+            Button("跳过") {
+                viewModel.skipCurrentReviewItem()
+            }
+            .buttonStyle(.borderless)
+            .foregroundColor(.secondary)
+        }
+    }
+
+    // MARK: - 复习完成
+
+    private var reviewCompleteView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("复习完成")
+                    .font(.headline)
+                Spacer()
+            }
+            Text("已完成 \(viewModel.reviewQueue.count) 项复习")
+                .foregroundColor(.secondary)
+            Button("退出复习模式") {
+                viewModel.exitReviewMode()
+            }
+        }
+    }
+
+    // MARK: - 无到期项
+
+    private var noDueItemsView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("复习模式")
+                    .font(.headline)
+                Spacer()
+            }
+            Text("暂无到期复习项")
+                .foregroundColor(.secondary)
+            Button("退出复习模式") {
+                viewModel.exitReviewMode()
+            }
+        }
+    }
+
+    // MARK: - Helper
+
+    private func reviewButton(_ title: String, quality: ReviewQuality, color: Color) -> some View {
+        Button(title) {
+            viewModel.submitReviewRating(quality)
+        }
+        .foregroundColor(color)
+        .buttonStyle(.bordered)
+    }
+}
+
+#Preview {
+    #if os(macOS)
+    ReviewModeView(viewModel: ViewModel(
+        platformService: MacOSPlatformService()
+    ))
+    #else
+    ReviewModeView(viewModel: ViewModel(
+        platformService: IOSPlatformService(presentingViewController: UIViewController())
+    ))
+    #endif
+}

--- a/XiangqiNotebook/Views/TogglesView.swift
+++ b/XiangqiNotebook/Views/TogglesView.swift
@@ -33,21 +33,29 @@ struct TogglesView: View {
             .padding(8) // 添加内边距，让内容不贴边
             .border(Color.gray)
 
-            // 棋盘操作
-            VStack(alignment: .leading) {
-                MyToggle(viewModel: viewModel, actionKey: .flip)
-                MyToggle(viewModel: viewModel, actionKey: .flipHorizontal)
-                MyToggle(viewModel: viewModel, actionKey: .toggleAutoExtendGameWhenPlayingBoardFen)
-                MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
-                MyToggle(viewModel: viewModel, actionKey: .toggleShowPath)
-                MyToggle(viewModel: viewModel, actionKey: .toggleShowAllNextMoves)
-                MyToggle(viewModel: viewModel, actionKey: .togglePracticeMode)
-                MyToggle(viewModel: viewModel, actionKey: .toggleIsCommentEditing)
-                MyToggle(viewModel: viewModel, actionKey: .toggleAllowAddingNewMoves)
-            }
-            .padding(8) // 添加内边距，让内容不贴边
-            .border(Color.gray)
+            BoardOperationTogglesView(viewModel: viewModel)
         }
+    }
+}
+
+/// 棋盘操作区域（独立组件，复习模式下也显示）
+struct BoardOperationTogglesView: View {
+    @ObservedObject var viewModel: ViewModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            MyToggle(viewModel: viewModel, actionKey: .flip)
+            MyToggle(viewModel: viewModel, actionKey: .flipHorizontal)
+            MyToggle(viewModel: viewModel, actionKey: .toggleAutoExtendGameWhenPlayingBoardFen)
+            MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
+            MyToggle(viewModel: viewModel, actionKey: .toggleShowPath)
+            MyToggle(viewModel: viewModel, actionKey: .toggleShowAllNextMoves)
+            MyToggle(viewModel: viewModel, actionKey: .togglePracticeMode)
+            MyToggle(viewModel: viewModel, actionKey: .toggleIsCommentEditing)
+            MyToggle(viewModel: viewModel, actionKey: .toggleAllowAddingNewMoves)
+        }
+        .padding(8)
+        .border(Color.gray)
     }
 }
 

--- a/XiangqiNotebook/Views/iOS/iPadContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPadContentView.swift
@@ -50,9 +50,21 @@ struct iPadContentView: View {
                         // 模式选择器
                         ModeSelectorView(viewModel: viewModel)
 
-                        TogglesView(viewModel: viewModel)
-                        BookmarkListView(viewModel: viewModel)
+                        if viewModel.isInReviewMode {
+                            // 复习模式：复习面板 + 复习库列表（填满） + 棋盘操作（底部）
+                            ReviewModeView(viewModel: viewModel)
+                            ScrollView {
+                                ReviewListView(viewModel: viewModel)
+                            }
+                            .border(Color.gray)
                             .frame(maxHeight: .infinity)
+                            BoardOperationTogglesView(viewModel: viewModel)
+                        } else {
+                            // 常规/练习模式：棋局筛选 + 书签
+                            TogglesView(viewModel: viewModel)
+                            BookmarkListView(viewModel: viewModel)
+                                .frame(maxHeight: .infinity)
+                        }
                     }
                     .frame(width: geometry.size.width * 0.2)
                 }

--- a/XiangqiNotebook/Views/iOS/iPhoneContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneContentView.swift
@@ -73,6 +73,9 @@ struct iPhoneContentView: View {
         .sheet(isPresented: $viewModel.showReviewListIOS) {
             iPhoneReviewListView(viewModel: viewModel, isPresented: $viewModel.showReviewListIOS)
         }
+        .sheet(isPresented: $viewModel.showReviewModeIOS) {
+            iPhoneReviewModeView(viewModel: viewModel, isPresented: $viewModel.showReviewModeIOS)
+        }
         .alert(viewModel.globalAlertTitle, isPresented: $viewModel.showingGlobalAlert) {
             Button("确定") { }
         } message: {

--- a/XiangqiNotebook/Views/iOS/iPhoneReviewModeView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneReviewModeView.swift
@@ -1,0 +1,174 @@
+#if os(iOS)
+import SwiftUI
+
+/// iPhone 版复习模式面板
+/// 以 sheet 形式呈现复习流程
+struct iPhoneReviewModeView: View {
+    @ObservedObject var viewModel: ViewModel
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 12) {
+                if viewModel.isReviewingInProgress {
+                    reviewInProgressView
+                } else if viewModel.isReviewComplete {
+                    reviewCompleteView
+                } else {
+                    noDueItemsView
+                }
+
+                Divider()
+
+                // 复习库列表
+                Text("复习库")
+                    .font(.headline)
+                    .padding(.horizontal)
+
+                if viewModel.reviewItemList.isEmpty {
+                    Text("暂无复习项")
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal)
+                    Spacer()
+                } else {
+                    ScrollView(showsIndicators: true) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(viewModel.reviewItemList, id: \.fenId) { item in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(viewModel.reviewItemDescription(fenId: item.fenId))
+                                            .lineLimit(1)
+                                        HStack(spacing: 8) {
+                                            Text(dueStatusText(item.srsData))
+                                                .font(.caption)
+                                                .foregroundColor(item.srsData.isDue ? .red : .secondary)
+                                            Text("已复习 \(item.srsData.repetitions) 次")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                        }
+                                    }
+                                    Spacer()
+                                }
+                                .padding(.vertical, 8)
+                                .padding(.horizontal)
+                                .background(item.fenId == viewModel.currentFenId ? Color.blue.opacity(0.1) : Color.clear)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    if let gamePath = item.srsData.gamePath {
+                                        viewModel.loadReviewItem(gamePath)
+                                    }
+                                }
+                                Divider()
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("复习模式")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("关闭") {
+                        isPresented = false
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    // MARK: - 复习进行中
+
+    private var reviewInProgressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            let item = viewModel.reviewQueue[viewModel.currentReviewIndex]
+            Text(viewModel.reviewItemDescription(fenId: item.fenId))
+                .lineLimit(2)
+                .padding(.horizontal)
+
+            Text("进度: \(viewModel.reviewProgress)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.horizontal)
+
+            // 自评按钮
+            HStack(spacing: 8) {
+                reviewButton("忘了", quality: .again, color: .red)
+                reviewButton("困难", quality: .hard, color: .orange)
+                reviewButton("良好", quality: .good, color: .blue)
+                reviewButton("简单", quality: .easy, color: .green)
+            }
+            .padding(.horizontal)
+
+            Button("跳过") {
+                viewModel.skipCurrentReviewItem()
+            }
+            .foregroundColor(.secondary)
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - 复习完成
+
+    private var reviewCompleteView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("已完成 \(viewModel.reviewQueue.count) 项复习")
+                .padding(.horizontal)
+            Button("退出复习模式") {
+                viewModel.exitReviewMode()
+                isPresented = false
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - 无到期项
+
+    private var noDueItemsView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("暂无到期复习项")
+                .foregroundColor(.secondary)
+                .padding(.horizontal)
+            Button("退出复习模式") {
+                viewModel.exitReviewMode()
+                isPresented = false
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - Helper
+
+    private func reviewButton(_ title: String, quality: ReviewQuality, color: Color) -> some View {
+        Button(title) {
+            viewModel.submitReviewRating(quality)
+        }
+        .foregroundColor(color)
+        .buttonStyle(.bordered)
+    }
+
+    private func dueStatusText(_ srsData: SRSData) -> String {
+        if srsData.isDue {
+            return "已到期"
+        }
+        let now = Date()
+        let days = Calendar.current.dateComponents([.day], from: now, to: srsData.nextReviewDate).day ?? 0
+        if days == 0 {
+            return "今天到期"
+        } else if days == 1 {
+            return "明天到期"
+        } else {
+            return "\(days)天后"
+        }
+    }
+}
+
+#Preview {
+    iPhoneReviewModeView(
+        viewModel: ViewModel(
+            platformService: IOSPlatformService(presentingViewController: UIViewController())
+        ),
+        isPresented: .constant(true)
+    )
+}
+#endif


### PR DESCRIPTION
## Summary
- 实现完整复习流程：进入复习模式 → 按到期顺序展示局面 → 用户自评（忘了/困难/良好/简单） → SM-2 更新间隔 → 下一项
- AppMode 新增 `review` case，复习模式下右栏替换为复习面板 + 复习库列表 + 棋盘操作
- 常规模式和练习模式界面完全不变（除 AppMode 多一个选项）
- 提取 `BoardOperationTogglesView` 为独立组件，复习模式下保留棋盘操作区域

Closes #32

## Test plan
- [x] 全部单元测试通过（含 8 个新测试）
- [x] 常规模式和练习模式界面完全不变
- [x] 选择复习模式后，右栏替换为复习面板+复习库列表+棋盘操作
- [x] 有到期项时按顺序展示，自评按钮正常更新 SRS 数据
- [x] 无到期项时显示提示
- [x] 复习完成显示完成提示
- [x] 退出复习模式回到常规模式，右栏恢复原状

🤖 Generated with [Claude Code](https://claude.com/claude-code)