### PR TITLE
增加下步变招列表，与本步变招左右并排显示

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1544,7 +1544,16 @@ class ViewModel: ObservableObject {
     var currentGameVariantListDisplay: [(moveString: String, move: Move)] {
         session.currentGameVariantList.sorted { $0.moveString < $1.moveString }
     }
-    
+
+    var currentNextMovesListDisplay: [(moveString: String, move: Move)] {
+        session.currentNextMovesList.sorted { $0.moveString < $1.moveString }
+    }
+
+    func playNextMove(_ move: Move) {
+        session.playNextMove(move)
+        queryFenScoreSilentlyIfNeeded()
+    }
+
     // 路径相关的属性
     var currentPathIndexDisplay: Int? { session.currentPathIndexDisplay }
     var totalPathsCount: Int? { session.totalPathsCount }

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -45,9 +45,12 @@ struct MacContentView: View {
                         MoveListView(viewModel: viewModel)
                             .frame(width: geometry.size.width * 0.2)
 
-                        // 变着列表
-                        VariantListView(viewModel: viewModel)
-                            .frame(height: geometry.size.height * 0.2)
+                        // 变着列表 + 下一步招法列表（左右并排）
+                        HStack(spacing: 0) {
+                            VariantListView(viewModel: viewModel)
+                            NextMovesListView(viewModel: viewModel)
+                        }
+                        .frame(height: geometry.size.height * 0.25)
                     }
                     .frame(width: geometry.size.width * 0.2)
 

--- a/XiangqiNotebook/Views/VariantListView.swift
+++ b/XiangqiNotebook/Views/VariantListView.swift
@@ -7,31 +7,72 @@ struct VariantListView: View {
     var body: some View {
         VStack(alignment: .leading) {
             HStack() {
-                Text("变着列表")
+                Text("本步变招")
                 Spacer()
             }
-            ScrollView(showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(viewModel.currentGameVariantListDisplay, id: \.move) { item in
-                        MoveItemView(
-                            text: viewModel.getMoveString(move: item.move),
-                            score: viewModel.getDisplayScoreForMove(item.move),
-                            isSelected: item.move.targetFenId == viewModel.currentFenId,
-                            isBadMove: viewModel.isBadMove(item.move),
-                            isRecommendedMove: viewModel.isRecommendedMove(item.move),
-                            isLocked: viewModel.isMoveLocked(viewModel.currentGameStepDisplay),
-                            onTap: {
-                                viewModel.playVariantMove(item.move)
-                            }
-                        )
-                        Divider()
+            if viewModel.currentGameVariantListDisplay.count > 1 {
+                ScrollView(showsIndicators: true) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(viewModel.currentGameVariantListDisplay, id: \.move) { item in
+                            MoveItemView(
+                                text: viewModel.getMoveString(move: item.move),
+                                score: viewModel.getDisplayScoreForMove(item.move),
+                                isSelected: item.move.targetFenId == viewModel.currentFenId,
+                                isBadMove: viewModel.isBadMove(item.move),
+                                isRecommendedMove: viewModel.isRecommendedMove(item.move),
+                                isLocked: viewModel.isMoveLocked(viewModel.currentGameStepDisplay),
+                                onTap: {
+                                    viewModel.playVariantMove(item.move)
+                                }
+                            )
+                            Divider()
+                        }
                     }
                 }
+                .scrollPosition(id: .constant(viewModel.currentGameVariantListDisplay.firstIndex(where: {
+                    $0.move.targetFenId == viewModel.currentFenId
+                })))
+                .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
             }
-            .scrollPosition(id: .constant(viewModel.currentGameVariantListDisplay.firstIndex(where: { 
-                $0.move.targetFenId == viewModel.currentFenId
-            })))
-            .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
+            Spacer()
+        }
+        .padding()
+        .border(Color.gray)
+    }
+}
+
+/// 下一步招法列表组件
+struct NextMovesListView: View {
+    @ObservedObject var viewModel: ViewModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack() {
+                Text("下步变招")
+                Spacer()
+            }
+            if viewModel.currentNextMovesListDisplay.count > 1 {
+                ScrollView(showsIndicators: true) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(viewModel.currentNextMovesListDisplay, id: \.move) { item in
+                            MoveItemView(
+                                text: viewModel.getMoveString(move: item.move),
+                                score: viewModel.getDisplayScoreForMove(item.move),
+                                isSelected: false,
+                                isBadMove: viewModel.isBadMove(item.move),
+                                isRecommendedMove: viewModel.isRecommendedMove(item.move),
+                                isLocked: false,
+                                onTap: {
+                                    viewModel.playNextMove(item.move)
+                                }
+                            )
+                            Divider()
+                        }
+                    }
+                }
+                .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
+            }
+            Spacer()
         }
         .padding()
         .border(Color.gray)
@@ -39,7 +80,7 @@ struct VariantListView: View {
 }
 
 /// 单个变着项视图
-private struct MoveItemView: View {
+struct MoveItemView: View {
     let text: String
     let score: String
     let isSelected: Bool

--- a/XiangqiNotebook/Views/iOS/iPadContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPadContentView.swift
@@ -40,8 +40,12 @@ struct iPadContentView: View {
                     VStack {
                         MoveListView(viewModel: viewModel)
                             .frame(width: geometry.size.width * 0.2)
+                        // 变着列表 + 下一步招法列表（左右并排）
+                    HStack(spacing: 0) {
                         VariantListView(viewModel: viewModel)
-                            .frame(height: geometry.size.height * 0.2)
+                        NextMovesListView(viewModel: viewModel)
+                    }
+                    .frame(height: geometry.size.height * 0.25)
                     }
                     .frame(width: geometry.size.width * 0.2)
                     


### PR DESCRIPTION
## Summary
- 在变招列表旁边新增「下步变招」列表，显示当前局面所有后续着法
- 两个列表左右并排显示，点击下步变招可跳转到对应局面
- 列表项数 ≤1 时只显示标题不显示内容，练习模式下隐藏内容

Closes #16

## Test plan
- [x] macOS 上验证本步变招和下步变招左右并排显示
- [ ] iPad 上验证同样的并排布局
- [x] 点击下步变招列表中的着法，确认跳转到正确局面
- [x] 验证列表项 ≤1 时只显示标题
- [x] 验证练习模式下列表内容隐藏
- [x] 单元测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)