### PR TITLE
招法列表中标记已加入复习库的步骤

### DIFF
--- a/XiangqiNotebook/Models/GameOperations.swift
+++ b/XiangqiNotebook/Models/GameOperations.swift
@@ -6,6 +6,7 @@ struct MoveListItem {
     let notation: String            // 招法符号，如 "炮二平五", "马8进7"
     let redOpeningMarker: String    // 红方开局库标识，"r" 或空字符串
     let blackOpeningMarker: String  // 黑方开局库标识，"b" 或空字符串
+    let reviewMarker: String        // 复习库标识，"v" 或空字符串
     let markers: String             // 标记符号，如 "++++", "+++"（表示变着数量）
     let move: Move?                 // 对应的 Move 对象
 }
@@ -210,7 +211,7 @@ class GameOperations {
                 // 开始位置：空序号，"开始"作为招法，无标记
                 moveList.append(MoveListItem(number: "", notation: "开始",
                                             redOpeningMarker: "", blackOpeningMarker: "",
-                                            markers: "", move: nil))
+                                            reviewMarker: "", markers: "", move: nil))
                 continue
             }
 
@@ -220,7 +221,7 @@ class GameOperations {
             guard let move = databaseView.move(from: prevFenId, to: curFenId) else {
                 moveList.append(MoveListItem(number: "", notation: "nil_bug",
                                             redOpeningMarker: "", blackOpeningMarker: "",
-                                            markers: "", move: nil))
+                                            reviewMarker: "", markers: "", move: nil))
                 continue
             }
 
@@ -241,6 +242,7 @@ class GameOperations {
             let curFenObject = databaseView.getFenObject(curFenId)
             let redOpeningMarker = curFenObject?.isInRedOpening == true ? "r" : ""
             let blackOpeningMarker = curFenObject?.isInBlackOpening == true ? "b" : ""
+            let reviewMarker = databaseView.reviewItems[curFenId] != nil ? "v" : ""
 
             let moves = databaseView.moves(from: prevFenId)
             let movesLength = moves.count
@@ -257,6 +259,7 @@ class GameOperations {
             moveList.append(MoveListItem(number: number, notation: notation,
                                         redOpeningMarker: redOpeningMarker,
                                         blackOpeningMarker: blackOpeningMarker,
+                                        reviewMarker: reviewMarker,
                                         markers: markers, move: move))
         }
 

--- a/XiangqiNotebook/Views/MoveListView.swift
+++ b/XiangqiNotebook/Views/MoveListView.swift
@@ -29,7 +29,12 @@ struct MoveListView: View {
                                 .frame(width: 8, alignment: .center)
                                 .foregroundColor(.secondary)
 
-                            // 第五列：变着标记（左对齐，获得剩余空间）
+                            // 第五列：复习库标识（居中对齐，固定宽度）
+                            Text(item.reviewMarker)
+                                .frame(width: 8, alignment: .center)
+                                .foregroundColor(.secondary)
+
+                            // 第六列：变着标记（左对齐，获得剩余空间）
                             Text(item.markers)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary
- 在 `MoveListItem` 结构体中添加 `reviewMarker` 字段
- `formatMoveList()` 通过检查 `databaseView.reviewItems` 为已加入复习库的局面标记 "v"
- `MoveListView` 在 r/b 列之后、变着标记之前新增一列显示复习库标识

Closes #44

## Test plan
- [x] 全部单元测试通过 (TEST SUCCEEDED)
- [x] 验证已加入复习库的步骤在招法列表中显示 "v" 标识
- [x] 验证未加入复习库的步骤不显示标识

🤖 Generated with [Claude Code](https://claude.com/claude-code)