### PR TITLE
修复复习模式下键盘快捷键失效问题

### DIFF
--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -366,6 +366,35 @@ class ActionDefinitions {
         return false
     }
     
+    /// 处理按键事件（用于 macOS NSEvent 监控，不依赖 SwiftUI 焦点系统）
+    func handleKeyDown(character: Character, command: Bool = false, control: Bool = false, option: Bool = false) -> Bool {
+        var modifiers = KeyModifiers()
+        if command { modifiers.insert(.command) }
+        if control { modifiers.insert(.control) }
+        if option { modifiers.insert(.option) }
+
+        if !modifiers.isEmpty {
+            let shortcutKey = ShortcutKey.modified(modifiers, character)
+            if let actionKey = shortcutLookup[shortcutKey] {
+                return executeAction(actionKey)
+            }
+        }
+
+        if isInSequenceMode {
+            return handleSequenceInput(character)
+        }
+
+        if modifiers.isEmpty {
+            let shortcutKey = ShortcutKey.single(character)
+            if let actionKey = shortcutLookup[shortcutKey] {
+                return executeAction(actionKey)
+            }
+            return startSequenceMode(with: character)
+        }
+
+        return false
+    }
+
     /// 处理按键事件（兼容旧版本）
     func handleKeyPress(_ key: KeyEquivalent) -> Bool {
         #if os(iOS) || os(tvOS) || os(watchOS)


### PR DESCRIPTION
## Summary

- 将键盘事件处理从 SwiftUI `.onKeyPress`（依赖焦点系统）改为 `NSEvent.addLocalMonitorForEvents`（AppKit 层级拦截），使快捷键不受控件焦点影响
- `ActionDefinitions` 新增 `handleKeyDown(character:command:control:option:)` 方法
- 保留原有的 TextEditor/TextField 焦点检查和 sheet 显示时禁用快捷键逻辑

**根因**：切换到复习模式时，SwiftUI 重建右侧面板，新面板中的 Button/Toggle 控件抢走 AppKit 焦点，导致 `.onKeyPress` 不再接收事件。

Closes #47

## Test plan

- [x] 常规模式下键盘快捷键正常工作
- [x] 切换到复习模式后键盘快捷键正常工作
- [x] 复习模式切回常规模式后键盘快捷键正常工作
- [x] 点击复习面板中的按钮后快捷键仍然工作
- [x] 评论编辑模式下 Escape 键正常退出编辑
- [x] Sheet 显示时快捷键被正确禁用
- [x] 全部单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)