### PR TITLE
状态栏增加走棋方提示

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1640,6 +1640,7 @@ class ViewModel: ObservableObject {
     var isBookmarked: Bool { session.isBookmarked }
     var isCurrentBlackOrientation: Bool { session.isCurrentBlackOrientation }
     var isCurrentHorizontalFlipped: Bool { session.isCurrentHorizontalFlipped }
+    var isRedTurn: Bool { session.blackJustPlayed }
     var isMyTurn: Bool {
         let iamBlack = session.isCurrentBlackOrientation
         let blackJustPlayed = session.blackJustPlayed

--- a/XiangqiNotebook/Views/StatusBarView.swift
+++ b/XiangqiNotebook/Views/StatusBarView.swift
@@ -46,6 +46,9 @@ struct StatusBarView: View {
     var body: some View {
         VStack {
             HStack {
+                Text("下步走子: \(viewModel.isRedTurn ? "红方" : "黑方")")
+                    .font(fontStyle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 Text("分数: \(viewModel.displayScore)")
                     .font(fontStyle)
                     .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))

--- a/XiangqiNotebook/Views/iOS/iPhoneStatusBarView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneStatusBarView.swift
@@ -38,6 +38,9 @@ struct iPhoneStatusBarView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
+                Text("下步走子: \(viewModel.isRedTurn ? "红方" : "黑方")")
+                    .font(fontStyle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 Text("分数: \(viewModel.displayScore)")
                     .font(fontStyle)
                     .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))


### PR DESCRIPTION
## Summary
- 在状态栏第一行开头添加"下步走子: 红方/黑方"指示器，帮助用户快速了解当前轮到哪方走棋
- ViewModel 新增 `isRedTurn` 计算属性（基于 `session.blackJustPlayed`）
- 同时支持 macOS/iPad（StatusBarView）和 iPhone（iPhoneStatusBarView）

Closes #53

## Test plan
- [x] 验证红方走棋时状态栏显示"下步走子: 红方"
- [x] 验证黑方走棋时状态栏显示"下步走子: 黑方"
- [x] 验证走棋后指示器自动切换
- [ ] 验证 macOS、iPad、iPhone 三端均正常显示
- [x] 全部自动化测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)