### PR TITLE
棋局浏览器记住折叠状态和选中项

### DIFF
--- a/XiangqiNotebook/Models/SessionData.swift
+++ b/XiangqiNotebook/Models/SessionData.swift
@@ -19,6 +19,9 @@ class SessionData: Codable {
     var specificGameId: UUID? = nil
     var specificBookId: UUID? = nil
     var allowAddingNewMoves: Bool = true
+    var gameBrowserExpandedBookIds: Set<UUID>? = nil
+    var gameBrowserSelectedBookId: UUID? = nil
+    var gameBrowserSelectedGameId: UUID? = nil
 
     init() {
         // 所有属性都已在声明时设置了默认值
@@ -48,6 +51,9 @@ class SessionData: Codable {
         case specificGameId = "specific_game_id"
         case specificBookId = "specific_book_id"
         case allowAddingNewMoves = "allow_adding_new_moves"
+        case gameBrowserExpandedBookIds = "game_browser_expanded_book_ids"
+        case gameBrowserSelectedBookId = "game_browser_selected_book_id"
+        case gameBrowserSelectedGameId = "game_browser_selected_game_id"
     }
 
     required init(from decoder: Decoder) throws {
@@ -77,6 +83,9 @@ class SessionData: Codable {
             currentMode = AppMode(rawValue: modeString) ?? .normal
         }
         allowAddingNewMoves = try container.decodeIfPresent(Bool.self, forKey: .allowAddingNewMoves) ?? true
+        gameBrowserExpandedBookIds = try container.decodeIfPresent(Set<UUID>.self, forKey: .gameBrowserExpandedBookIds)
+        gameBrowserSelectedBookId = try container.decodeIfPresent(UUID.self, forKey: .gameBrowserSelectedBookId)
+        gameBrowserSelectedGameId = try container.decodeIfPresent(UUID.self, forKey: .gameBrowserSelectedGameId)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -100,5 +109,8 @@ class SessionData: Codable {
         try container.encodeIfPresent(specificBookId, forKey: .specificBookId)
         try container.encode(currentMode, forKey: .currentMode)
         try container.encode(allowAddingNewMoves, forKey: .allowAddingNewMoves)
+        try container.encodeIfPresent(gameBrowserExpandedBookIds, forKey: .gameBrowserExpandedBookIds)
+        try container.encodeIfPresent(gameBrowserSelectedBookId, forKey: .gameBrowserSelectedBookId)
+        try container.encodeIfPresent(gameBrowserSelectedGameId, forKey: .gameBrowserSelectedGameId)
     }
 }


### PR DESCRIPTION
## Summary
- 在 SessionData 中新增 3 个持久化字段：棋谱树展开状态、选中棋谱 ID、选中棋局 ID
- GameBrowserView 在打开时从 SessionData 恢复状态，变更时通过 onChange 写回
- BookTreeNodeView 的展开/折叠改为共享 Set<UUID> 驱动，nil 表示全部展开
- 向后兼容：旧 session.json 无新字段时使用默认值（全部展开、无选中项）

Closes #52

## Test plan
- [x] 打开棋局浏览器，折叠某些棋谱节点，选中一个棋局
- [x] 关闭浏览器，重新打开，验证折叠状态和选中项恢复
- [x] 在有特定棋局筛选时打开浏览器，验证优先定位到筛选棋局
- [x] 保存后退出 app，重新启动，打开浏览器验证状态持久化
- [x] 全部 407 个单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)