### PR TITLE
导出PGN：基于 DatabaseView 树路径导出

### DIFF
--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -38,6 +38,12 @@ final class DatabaseView {
         return database.databaseData.fenObjects2[fenId]
     }
 
+    /// 获取 FenObject（不受 scope 过滤影响）
+    /// - Note: 用于需要访问所有局面的场景（如 PGN 导出时遍历完整树结构）
+    func getFenObjectUnfiltered(_ fenId: Int) -> FenObject? {
+        return database.databaseData.fenObjects2[fenId]
+    }
+
     /// 检查 fenId 是否属于当前视图 scope
     func containsFenId(_ fenId: Int) -> Bool {
         return fenIdFilter(fenId)

--- a/XiangqiNotebook/Models/PGNExportService.swift
+++ b/XiangqiNotebook/Models/PGNExportService.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+enum PGNExportService {
+
+    /// Export all root-to-leaf paths in the DatabaseView tree as PGN games
+    static func exportPGN(databaseView: DatabaseView, rootFenId: Int) -> String {
+        let paths = generateAllPaths(databaseView: databaseView, rootFenId: rootFenId)
+        var pgnStrings: [String] = []
+        for (index, path) in paths.enumerated() {
+            if let pgn = exportPath(path, gameNumber: index + 1, databaseView: databaseView) {
+                pgnStrings.append(pgn)
+            }
+        }
+        return pgnStrings.joined(separator: "\n\n")
+    }
+
+    /// DFS traversal of the DatabaseView tree, collecting all root-to-leaf paths as [[Int]]
+    ///
+    /// Uses `databaseView.moves(from:)` which enforces scope filtering (both source and target
+    /// must be in scope). For opening views, this means only positions explicitly marked as
+    /// belonging to the opening are traversed, keeping the export bounded.
+    static func generateAllPaths(databaseView: DatabaseView, rootFenId: Int) -> [[Int]] {
+        guard databaseView.containsFenId(rootFenId) else { return [] }
+
+        var result: [[Int]] = []
+        var stack: [(fenId: Int, path: [Int])] = [(rootFenId, [rootFenId])]
+
+        while !stack.isEmpty {
+            let (currentFenId, currentPath) = stack.removeLast()
+            let moves = databaseView.moves(from: currentFenId)
+            let validNextIds = moves.compactMap { move -> Int? in
+                guard let targetFenId = move.targetFenId else { return nil }
+                guard !currentPath.contains(targetFenId) else { return nil }
+                return targetFenId
+            }
+
+            if validNextIds.isEmpty {
+                if currentPath.count >= 2 {
+                    result.append(currentPath)
+                }
+            } else {
+                for nextFenId in validNextIds {
+                    stack.append((nextFenId, currentPath + [nextFenId]))
+                }
+            }
+        }
+
+        return result
+    }
+
+    /// Convert a fenId path to a PGN string
+    static func exportPath(_ path: [Int], gameNumber: Int, databaseView: DatabaseView) -> String? {
+        guard path.count >= 2 else { return nil }
+
+        // Convert consecutive FEN pairs to coordinate moves
+        // Use getFenObjectUnfiltered since the path may include positions not in scope
+        // (e.g., intermediate positions in opening views)
+        var coordMoves: [String] = []
+        for i in 0..<(path.count - 1) {
+            guard let fenObj1 = databaseView.getFenObjectUnfiltered(path[i]),
+                  let fenObj2 = databaseView.getFenObjectUnfiltered(path[i + 1]) else {
+                return nil
+            }
+            guard let pieceMove = extractPieceMoveFromFens(fen1: fenObj1.fen, fen2: fenObj2.fen) else {
+                return nil
+            }
+            coordMoves.append(PGNParser.pieceMoveToCoord(pieceMove))
+        }
+
+        // Build minimal headers
+        var headers: [String] = []
+        headers.append("[Game \"\(gameNumber)\"]")
+        headers.append("[Result \"*\"]")
+
+        // Add FEN header if starting position is non-standard
+        if let startFenObj = databaseView.getFenObjectUnfiltered(path[0]) {
+            let standardStartFen = normalizeFen(XiangqiBoardUtils.startFEN)
+            if startFenObj.fen != standardStartFen {
+                let pgnFen = PGNParser.appFenToPgnFen(startFenObj.fen)
+                headers.append("[FEN \"\(pgnFen)\"]")
+            }
+        }
+
+        // Build movetext
+        var movetext = ""
+        for i in 0..<coordMoves.count {
+            if i % 2 == 0 {
+                movetext += "\(i / 2 + 1). "
+            }
+            movetext += coordMoves[i]
+            if i < coordMoves.count - 1 {
+                movetext += " "
+            }
+        }
+        movetext += " *"
+
+        return headers.joined(separator: "\n") + "\n" + movetext
+    }
+
+    // MARK: - Private Helpers
+
+    /// Extract PieceMove by comparing two FEN strings directly
+    private static func extractPieceMoveFromFens(fen1: String, fen2: String) -> PieceMove? {
+        let fenObj1 = FenObject(fen: fen1, fenId: 0)
+        let fenObj2 = FenObject(fen: fen2, fenId: 1)
+        let tempFenObjects: [Int: FenObject] = [0: fenObj1, 1: fenObj2]
+        return Move.extractPieceMove(fenObjects2: tempFenObjects, from: 0, to: 1)
+    }
+}

--- a/XiangqiNotebook/Models/PGNParser.swift
+++ b/XiangqiNotebook/Models/PGNParser.swift
@@ -267,6 +267,36 @@ enum PGNParser {
         return (fenSequence, false)
     }
 
+    // MARK: - Reverse Conversion (Export)
+
+    /// Convert app FEN to PGN FEN format
+    /// App uses "r" for red's turn with " - - 1 1" suffix; PGN uses "w" without suffix
+    static func appFenToPgnFen(_ fen: String) -> String {
+        let parts = fen.split(separator: " ", maxSplits: 1)
+        guard parts.count >= 1 else { return fen }
+        let boardPart = String(parts[0])
+        let turnChar = parts.count > 1 ? String(parts[1].prefix(1)) : "w"
+        let pgnTurn = turnChar == "r" ? "w" : "b"
+        return boardPart + " " + pgnTurn
+    }
+
+    /// Convert PieceMove to PGN coordinate string (e.g., "h2e2")
+    /// PieceMove row/column come from FEN rows: row 0 = top (black side) = PGN row 0
+    static func pieceMoveToCoord(_ pieceMove: PieceMove) -> String {
+        let columns = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+        return "\(columns[pieceMove.fromColumn])\(pieceMove.fromRow)\(columns[pieceMove.toColumn])\(pieceMove.toRow)"
+    }
+
+    /// Convert GameResult to PGN result string
+    static func gameResultToPgnResult(_ result: GameResult) -> String {
+        switch result {
+        case .redWin: return "1-0"
+        case .blackWin: return "0-1"
+        case .draw: return "1/2-1/2"
+        case .notFinished, .unknown: return "*"
+        }
+    }
+
     // MARK: - Result Parsing
 
     /// Parse PGN result string to GameResult

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -49,6 +49,7 @@ class ActionDefinitions {
         case practiceBlackOpening
         case searchCurrentMove
         case importPGN  // 新增：导入PGN按钮
+        case exportPGN  // 新增：导出PGN按钮
         case autoAddToOpening  // 新增：自动完善开局库
         case jumpToNextOpeningGap  // 新增：跳转到下一个开局缺口
         case queryEngineScore  // 手动触发引擎评估

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -304,6 +304,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.inputGame, text: "录入棋局", shortcuts: [.sequence(",i")], supportedModes: [.normal]) { self.showingGameInputView = true }
         actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",fff")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
         actionDefinitions.registerAction(.importPGN, text: "导入PGN", shortcuts: [.sequence(",p")], supportedModes: [.normal]) { self.showingPGNImportSheet = true }
+        actionDefinitions.registerAction(.exportPGN, text: "导出PGN...", supportedModes: [.normal]) { self.exportPGN() }
 
         actionDefinitions.registerAction(.fix, text: "修复", shortcuts: [.sequence(",fix")], supportedModes: [.normal]) { self.session.recalculateGameStatistics() }
         actionDefinitions.registerAction(.autoAddToOpening, text: "自动完善开局库", supportedModes: [.normal]) { self.performAutoAddToOpening() }
@@ -1796,6 +1797,34 @@ class ViewModel: ObservableObject {
         }
         return result
     }
+
+    func exportPGNContent() -> String {
+        let rootFenId = session.sessionData.currentGame2[0]
+        return PGNExportService.exportPGN(databaseView: session.databaseView, rootFenId: rootFenId)
+    }
+
+    #if os(macOS)
+    func exportPGN() {
+        let content = exportPGNContent()
+        guard !content.isEmpty else {
+            showGlobalAlert(title: "导出PGN", message: "当前范围内没有可导出的路径")
+            return
+        }
+
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [.plainText]
+        savePanel.nameFieldStringValue = "export.pgn"
+        savePanel.title = "导出PGN"
+
+        guard savePanel.runModal() == .OK, let url = savePanel.url else { return }
+
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            showGlobalAlert(title: "导出失败", message: error.localizedDescription)
+        }
+    }
+    #endif
 
     func getGameObjectUnfiltered(_ gameId: UUID) -> GameObject? {
         return session.getGameObjectUnfiltered(gameId)

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -233,6 +233,7 @@ struct MacMenuCommands: Commands {
             Divider()
             menuButton(.checkDataVersion)
             menuButton(.importPGN)
+            menuButton(.exportPGN)
             menuButton(.inputGame)
             menuButton(.browseGames)
         }

--- a/XiangqiNotebookTests/PGNExportTests.swift
+++ b/XiangqiNotebookTests/PGNExportTests.swift
@@ -1,0 +1,260 @@
+import Foundation
+import Testing
+@testable import XiangqiNotebook
+
+struct PGNExportTests {
+
+    // MARK: - PGNParser helper tests (preserved)
+
+    @Test func testAppFenToPgnFen() {
+        let appFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let pgnFen = PGNParser.appFenToPgnFen(appFen)
+        #expect(pgnFen == "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR w")
+    }
+
+    @Test func testAppFenToPgnFenBlackTurn() {
+        let appFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C2C2C1/9/RNBAKABNR b - - 1 1"
+        let pgnFen = PGNParser.appFenToPgnFen(appFen)
+        #expect(pgnFen == "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C2C2C1/9/RNBAKABNR b")
+    }
+
+    @Test func testPieceMoveToCoord() {
+        let move = PieceMove(piece: "C", fromRow: 7, fromColumn: 7, toRow: 7, toColumn: 4)
+        #expect(PGNParser.pieceMoveToCoord(move) == "h7e7")
+    }
+
+    @Test func testPieceMoveToCoordKnightMove() {
+        let move = PieceMove(piece: "N", fromRow: 9, fromColumn: 7, toRow: 7, toColumn: 6)
+        #expect(PGNParser.pieceMoveToCoord(move) == "h9g7")
+    }
+
+    @Test func testGameResultToPgnResult() {
+        #expect(PGNParser.gameResultToPgnResult(.redWin) == "1-0")
+        #expect(PGNParser.gameResultToPgnResult(.blackWin) == "0-1")
+        #expect(PGNParser.gameResultToPgnResult(.draw) == "1/2-1/2")
+        #expect(PGNParser.gameResultToPgnResult(.notFinished) == "*")
+        #expect(PGNParser.gameResultToPgnResult(.unknown) == "*")
+    }
+
+    @Test func testFenRoundTrip() {
+        let originalAppFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let pgnFen = PGNParser.appFenToPgnFen(originalAppFen)
+        let roundTrippedAppFen = PGNParser.pgnFenToAppFen(pgnFen)
+        #expect(roundTrippedAppFen == originalAppFen)
+    }
+
+    // MARK: - Export: Empty Database
+
+    @Test func testExportEmptyDatabase() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        #expect(exported.isEmpty)
+    }
+
+    // MARK: - Export: Linear Path (root → A → B)
+
+    @Test func testExportLinearPath() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+
+        let pgn = """
+        [Game "1"]
+        [Red "A"]
+        [Black "B"]
+        [Result "*"]
+
+        1. h2e2 h9g7 *
+        """
+        let result = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
+        #expect(result.imported == 1)
+
+        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        #expect(!exported.isEmpty)
+
+        // Verify minimal headers (no player names, no date)
+        #expect(exported.contains("[Game \"1\"]"))
+        #expect(exported.contains("[Result \"*\"]"))
+        #expect(!exported.contains("[Red"))
+        #expect(!exported.contains("[Black"))
+        #expect(!exported.contains("[Date"))
+
+        // Standard starting position: no FEN header
+        #expect(!exported.contains("[FEN"))
+
+        // Should contain movetext
+        #expect(exported.contains("1."))
+    }
+
+    // MARK: - Export: Branching Tree (root → A → B, root → A → C)
+
+    @Test func testExportBranchingTree() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+
+        let pgn = """
+        [Game "1"]
+        [Red "A"]
+        [Black "B"]
+        [Result "*"]
+
+        1. h2e2 h9g7 *
+
+        [Game "2"]
+        [Red "C"]
+        [Black "D"]
+        [Result "*"]
+
+        1. h2e2 b9c7 *
+        """
+        let result = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
+        #expect(result.imported == 2)
+
+        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        #expect(!exported.isEmpty)
+
+        // Should produce 2 PGN games (2 distinct root-to-leaf paths)
+        let games = exported.components(separatedBy: "\n\n")
+        #expect(games.count == 2)
+
+        #expect(exported.contains("[Game \"1\"]"))
+        #expect(exported.contains("[Game \"2\"]"))
+    }
+
+    // MARK: - generateAllPaths Direct Tests
+
+    @Test func testGenerateAllPathsEmpty() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+        let paths = PGNExportService.generateAllPaths(databaseView: databaseView, rootFenId: 1)
+        #expect(paths.isEmpty)
+    }
+
+    @Test func testGenerateAllPathsLinear() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+
+        let pgn = """
+        [Game "1"]
+        [Result "*"]
+
+        1. h2e2 h9g7 *
+        """
+        _ = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
+
+        let paths = PGNExportService.generateAllPaths(databaseView: databaseView, rootFenId: 1)
+        #expect(paths.count == 1)
+        #expect(paths[0].count == 3) // root + 2 moves = 3 fenIds
+        #expect(paths[0].first == 1) // starts from root
+    }
+
+    @Test func testGenerateAllPathsBranching() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+
+        let pgn = """
+        [Game "1"]
+        [Result "*"]
+
+        1. h2e2 h9g7 *
+
+        [Game "2"]
+        [Result "*"]
+
+        1. h2e2 b9c7 *
+        """
+        _ = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
+
+        let paths = PGNExportService.generateAllPaths(databaseView: databaseView, rootFenId: 1)
+        #expect(paths.count == 2)
+        #expect(paths[0][0] == paths[1][0]) // same root
+        #expect(paths[0][1] == paths[1][1]) // same after first move
+        #expect(paths[0][2] != paths[1][2]) // diverge at third
+    }
+
+    // MARK: - Red Opening View exports full tree
+
+    @Test func testExportFromRedOpeningView() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let fullView = DatabaseView.full(database: database)
+
+        // Import a game to create tree structure
+        let pgn = """
+        [Game "1"]
+        [Result "*"]
+
+        1. h2e2 h9g7 *
+        """
+        let result = PGNImportService.importPGN(content: pgn, username: "", databaseView: fullView)
+        #expect(result.imported == 1)
+
+        // Find the root fenId (standard start)
+        let startFen = normalizeFen(XiangqiBoardUtils.startFEN)
+        guard let rootFenId = fullView.getIdForFen(startFen) else {
+            #expect(Bool(false), "Standard start FEN should exist")
+            return
+        }
+
+        // Mark b-turn positions (after red's move) as inRedOpening
+        // so the red opening view tree is connected
+        let allFenIds = fullView.getAllFenIds()
+        for fenId in allFenIds {
+            if let fenObj = fullView.getFenObject(fenId), fenObj.redJustPlayed {
+                fenObj.setInRedOpening(true)
+            }
+        }
+
+        let redView = DatabaseView.redOpening(database: database)
+        let paths = PGNExportService.generateAllPaths(databaseView: redView, rootFenId: rootFenId)
+        #expect(paths.count == 1)
+        #expect(paths[0].count == 3)
+
+        let exported = PGNExportService.exportPGN(databaseView: redView, rootFenId: rootFenId)
+        #expect(!exported.isEmpty)
+        #expect(exported.contains("1."))
+    }
+
+    // MARK: - Non-standard Starting FEN
+
+    @Test func testExportWithCustomStartingFen() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+
+        let customFen = normalizeFen("rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKAB1R r")
+        let afterMoveFen = normalizeFen("rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABR1 b")
+
+        let fenId1 = databaseView.ensureFenId(for: customFen)
+        let fenId2 = databaseView.ensureFenId(for: afterMoveFen)
+        let (move, _, _) = databaseView.ensureMove(from: fenId1, to: fenId2)
+        if let fenObject = databaseView.getFenObject(fenId1) {
+            _ = fenObject.addMoveIfNeeded(move: move)
+        }
+
+        // Export the path directly
+        let pgn = PGNExportService.exportPath([fenId1, fenId2], gameNumber: 1, databaseView: databaseView)
+        #expect(pgn != nil)
+        #expect(pgn!.contains("[FEN"))
+    }
+
+    // MARK: - Single Node (root only, no moves)
+
+    @Test func testExportSingleNodeReturnsEmpty() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+        let result = PGNExportService.exportPath([1], gameNumber: 1, databaseView: databaseView)
+        #expect(result == nil)
+    }
+
+    // MARK: - Database without fenId=1
+
+    @Test func testExportWithoutFenId1() {
+        // Empty DatabaseData has no fenId=1
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+        // DatabaseData() creates empty data with no fenObjects — fenId=1 doesn't exist
+        // But DatabaseStorage.createEmptyDatabase() creates fenId=1
+        // With empty DatabaseData, getFenObjectUnfiltered(1) returns nil → empty
+        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        #expect(exported.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- 重写 PGN 导出功能：DFS 遍历 DatabaseView 树，将每条根到叶路径导出为一个 PGN 棋局
- 新增 `PGNExportService`（generateAllPaths + exportPath），使用 `databaseView.moves(from:)` 遍历 scope 内的树结构
- `DatabaseView` 新增 `getFenObjectUnfiltered()` 用于导出时获取 FEN 字符串
- `PGNParser` 新增反向转换方法（appFenToPgnFen、pieceMoveToCoord、gameResultToPgnResult）
- macOS 文件菜单新增"导出PGN..."操作，树根从 `currentGame2[0]` 获取

Closes #58

## Test plan

- [x] 空数据库导出返回空字符串
- [x] 线性路径（root→A→B）导出为 1 个 PGN
- [x] 分支树（root→A→B, root→A→C）导出为 2 个 PGN
- [x] 红方开局视图导出（需 b-turn 位置标记 inRedOpening）
- [x] 非标准起始 FEN 包含 [FEN] header
- [x] 标准起始 FEN 不包含 [FEN] header
- [x] generateAllPaths 直接测试
- [x] 全部 16 个测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)