### PR TITLE
状态栏显示FEN并支持拷贝 (#60)

### DIFF
--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -52,6 +52,7 @@ class ActionDefinitions {
         case exportPGN  // 新增：导出PGN按钮
         case autoAddToOpening  // 新增：自动完善开局库
         case jumpToNextOpeningGap  // 新增：跳转到下一个开局缺口
+        case copyFEN  // 拷贝当前FEN到剪贴板
         case queryEngineScore  // 手动触发引擎评估
         case queryAllEngineScores  // 搜索本对局每一步的引擎分数
 

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -306,6 +306,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.importPGN, text: "导入PGN", shortcuts: [.sequence(",p")], supportedModes: [.normal]) { self.showingPGNImportSheet = true }
         actionDefinitions.registerAction(.exportPGN, text: "导出PGN...", supportedModes: [.normal]) { self.exportPGN() }
 
+        actionDefinitions.registerAction(.copyFEN, text: "拷贝FEN", shortcuts: [.sequence(",f")]) { self.copyFenToClipboard() }
         actionDefinitions.registerAction(.fix, text: "修复", shortcuts: [.sequence(",fix")], supportedModes: [.normal]) { self.session.recalculateGameStatistics() }
         actionDefinitions.registerAction(.autoAddToOpening, text: "自动完善开局库", supportedModes: [.normal]) { self.performAutoAddToOpening() }
         actionDefinitions.registerAction(.jumpToNextOpeningGap, text: "跳转开局缺口", shortcuts: [.sequence(",o")], supportedModes: [.normal]) { self.jumpToNextOpeningGap() }
@@ -1391,6 +1392,16 @@ class ViewModel: ObservableObject {
 
     #endif
 
+    func copyFenToClipboard() {
+        let fen = displayFen
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(fen, forType: .string)
+        #else
+        UIPasteboard.general.string = fen
+        #endif
+    }
+
     func openYunku() {
         let fen = session.currentFen
         let yunkuFen = fen.split(separator: " - ")[0]
@@ -1490,6 +1501,20 @@ class ViewModel: ObservableObject {
     // MARK: - 计算属性
     
     // 从 Session 转发的计算属性
+    var currentFen: String { session.currentFen }
+    /// 用于显示和拷贝的 FEN：`r` → `w`，尾部 `1 1` → `0 1`
+    var displayFen: String {
+        var fen = session.currentFen
+        // r → w（红方用标准 FEN 的 w 表示）
+        if let range = fen.range(of: " r ", options: .backwards) {
+            fen.replaceSubrange(range, with: " w ")
+        }
+        // 尾部 - - 1 1 → - - 0 1
+        if fen.hasSuffix(" - - 1 1") {
+            fen = String(fen.dropLast(7)) + "- - 0 1"
+        }
+        return fen
+    }
     var currentFenId: Int { session.currentFenId }
     var displayScore: String { session.displayScore }
     var displayEngineScore: String { session.displayEngineScore }

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -246,6 +246,8 @@ struct MacMenuCommands: Commands {
             menuButton(.deleteScore)
             Divider()
             menuButton(.fix)
+            Divider()
+            menuButton(.copyFEN)
         }
 
         // 显示 menu

--- a/XiangqiNotebook/Views/StatusBarView.swift
+++ b/XiangqiNotebook/Views/StatusBarView.swift
@@ -45,6 +45,15 @@ struct StatusBarView: View {
 
     var body: some View {
         VStack {
+            Text("FEN: \(viewModel.displayFen)")
+                .font(fontStyle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .padding(.vertical, verticalPadding)
+                .padding(.horizontal)
+                .border(Color.gray)
+
             HStack {
                 Text("下步走子: \(viewModel.isRedTurn ? "红方" : "黑方")")
                     .font(fontStyle)

--- a/XiangqiNotebook/Views/iOS/iPhoneStatusBarView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneStatusBarView.swift
@@ -37,6 +37,17 @@ struct iPhoneStatusBarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            Text("FEN: \(viewModel.displayFen)")
+                .font(fontStyle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .padding(.vertical, verticalPadding)
+                .padding(.horizontal)
+
+            Divider()
+            .background(Color.gray)
+
             HStack {
                 Text("下步走子: \(viewModel.isRedTurn ? "红方" : "黑方")")
                     .font(fontStyle)


### PR DESCRIPTION
- 状态栏顶部新增 FEN 显示行（macOS/iPad/iPhone）
- 编辑菜单新增"拷贝FEN"项，快捷键 ,f
- 显示和拷贝的 FEN 使用标准格式：r→w、尾部 0 1
- 新增 ActionKey.copyFEN 和 displayFen 计算属性

Closes #60