### PR TITLE
PGN导出：区分所有变着导出和当前棋局导出

### DIFF
--- a/XiangqiNotebook/Models/PGNExportService.swift
+++ b/XiangqiNotebook/Models/PGNExportService.swift
@@ -3,7 +3,7 @@ import Foundation
 enum PGNExportService {
 
     /// Export all root-to-leaf paths in the DatabaseView tree as PGN games
-    static func exportPGN(databaseView: DatabaseView, rootFenId: Int) -> String {
+    static func exportCurrentDatabaseView(databaseView: DatabaseView, rootFenId: Int) -> String {
         let paths = generateAllPaths(databaseView: databaseView, rootFenId: rootFenId)
         var pgnStrings: [String] = []
         for (index, path) in paths.enumerated() {
@@ -95,6 +95,14 @@ enum PGNExportService {
         movetext += " *"
 
         return headers.joined(separator: "\n") + "\n" + movetext
+    }
+
+    /// Export a single game path (currentGame2) as PGN
+    static func exportCurrentGame(path: [Int], databaseView: DatabaseView) -> String {
+        guard let pgn = exportPath(path, gameNumber: 1, databaseView: databaseView) else {
+            return ""
+        }
+        return pgn
     }
 
     // MARK: - Private Helpers

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -49,7 +49,8 @@ class ActionDefinitions {
         case practiceBlackOpening
         case searchCurrentMove
         case importPGN  // 新增：导入PGN按钮
-        case exportPGN  // 新增：导出PGN按钮
+        case exportPGNCurrentDatabaseView  // 导出所有变着PGN
+        case exportPGNCurrentGame  // 导出当前棋局PGN
         case autoAddToOpening  // 新增：自动完善开局库
         case jumpToNextOpeningGap  // 新增：跳转到下一个开局缺口
         case copyFEN  // 拷贝当前FEN到剪贴板

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -304,7 +304,8 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.inputGame, text: "录入棋局", shortcuts: [.sequence(",i")], supportedModes: [.normal]) { self.showingGameInputView = true }
         actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",fff")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
         actionDefinitions.registerAction(.importPGN, text: "导入PGN", shortcuts: [.sequence(",p")], supportedModes: [.normal]) { self.showingPGNImportSheet = true }
-        actionDefinitions.registerAction(.exportPGN, text: "导出PGN...", supportedModes: [.normal]) { self.exportPGN() }
+        actionDefinitions.registerAction(.exportPGNCurrentDatabaseView, text: "导出所有变着PGN...", supportedModes: [.normal]) { self.exportPGNCurrentDatabaseView() }
+        actionDefinitions.registerAction(.exportPGNCurrentGame, text: "导出当前棋局PGN...", supportedModes: [.normal]) { self.exportPGNCurrentGame() }
 
         actionDefinitions.registerAction(.copyFEN, text: "拷贝FEN", shortcuts: [.sequence(",f")]) { self.copyFenToClipboard() }
         actionDefinitions.registerAction(.fix, text: "修复", shortcuts: [.sequence(",fix")], supportedModes: [.normal]) { self.session.recalculateGameStatistics() }
@@ -1823,14 +1824,19 @@ class ViewModel: ObservableObject {
         return result
     }
 
-    func exportPGNContent() -> String {
+    func exportPGNCurrentDatabaseViewContent() -> String {
         let rootFenId = session.sessionData.currentGame2[0]
-        return PGNExportService.exportPGN(databaseView: session.databaseView, rootFenId: rootFenId)
+        return PGNExportService.exportCurrentDatabaseView(databaseView: session.databaseView, rootFenId: rootFenId)
+    }
+
+    func exportPGNCurrentGameContent() -> String {
+        let path = session.sessionData.currentGame2
+        return PGNExportService.exportCurrentGame(path: path, databaseView: session.databaseView)
     }
 
     #if os(macOS)
-    func exportPGN() {
-        let content = exportPGNContent()
+    func exportPGNCurrentDatabaseView() {
+        let content = exportPGNCurrentDatabaseViewContent()
         guard !content.isEmpty else {
             showGlobalAlert(title: "导出PGN", message: "当前范围内没有可导出的路径")
             return
@@ -1839,7 +1845,28 @@ class ViewModel: ObservableObject {
         let savePanel = NSSavePanel()
         savePanel.allowedContentTypes = [.plainText]
         savePanel.nameFieldStringValue = "export.pgn"
-        savePanel.title = "导出PGN"
+        savePanel.title = "导出所有变着PGN"
+
+        guard savePanel.runModal() == .OK, let url = savePanel.url else { return }
+
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            showGlobalAlert(title: "导出失败", message: error.localizedDescription)
+        }
+    }
+
+    func exportPGNCurrentGame() {
+        let content = exportPGNCurrentGameContent()
+        guard !content.isEmpty else {
+            showGlobalAlert(title: "导出PGN", message: "当前棋局没有可导出的着法")
+            return
+        }
+
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [.plainText]
+        savePanel.nameFieldStringValue = "export.pgn"
+        savePanel.title = "导出当前棋局PGN"
 
         guard savePanel.runModal() == .OK, let url = savePanel.url else { return }
 

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -233,7 +233,8 @@ struct MacMenuCommands: Commands {
             Divider()
             menuButton(.checkDataVersion)
             menuButton(.importPGN)
-            menuButton(.exportPGN)
+            menuButton(.exportPGNCurrentDatabaseView)
+            menuButton(.exportPGNCurrentGame)
             menuButton(.inputGame)
             menuButton(.browseGames)
         }

--- a/XiangqiNotebookTests/PGNExportTests.swift
+++ b/XiangqiNotebookTests/PGNExportTests.swift
@@ -48,7 +48,7 @@ struct PGNExportTests {
     @Test func testExportEmptyDatabase() {
         let database = Database(testDatabaseData: DatabaseData())
         let databaseView = DatabaseView.full(database: database)
-        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        let exported = PGNExportService.exportCurrentDatabaseView(databaseView: databaseView, rootFenId: 1)
         #expect(exported.isEmpty)
     }
 
@@ -69,7 +69,7 @@ struct PGNExportTests {
         let result = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
         #expect(result.imported == 1)
 
-        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        let exported = PGNExportService.exportCurrentDatabaseView(databaseView: databaseView, rootFenId: 1)
         #expect(!exported.isEmpty)
 
         // Verify minimal headers (no player names, no date)
@@ -110,7 +110,7 @@ struct PGNExportTests {
         let result = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
         #expect(result.imported == 2)
 
-        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        let exported = PGNExportService.exportCurrentDatabaseView(databaseView: databaseView, rootFenId: 1)
         #expect(!exported.isEmpty)
 
         // Should produce 2 PGN games (2 distinct root-to-leaf paths)
@@ -209,7 +209,7 @@ struct PGNExportTests {
         #expect(paths.count == 1)
         #expect(paths[0].count == 3)
 
-        let exported = PGNExportService.exportPGN(databaseView: redView, rootFenId: rootFenId)
+        let exported = PGNExportService.exportCurrentDatabaseView(databaseView: redView, rootFenId: rootFenId)
         #expect(!exported.isEmpty)
         #expect(exported.contains("1."))
     }
@@ -245,6 +245,44 @@ struct PGNExportTests {
         #expect(result == nil)
     }
 
+    // MARK: - exportCurrentGame Tests
+
+    @Test func testExportCurrentGameLinearPath() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+
+        let pgn = """
+        [Game "1"]
+        [Result "*"]
+
+        1. h2e2 h9g7 *
+        """
+        _ = PGNImportService.importPGN(content: pgn, username: "", databaseView: databaseView)
+
+        // Build currentGame2-like path: root → after h2e2 → after h9g7
+        let paths = PGNExportService.generateAllPaths(databaseView: databaseView, rootFenId: 1)
+        #expect(paths.count == 1)
+
+        let exported = PGNExportService.exportCurrentGame(path: paths[0], databaseView: databaseView)
+        #expect(!exported.isEmpty)
+        #expect(exported.contains("[Game \"1\"]"))
+        #expect(exported.contains("1."))
+    }
+
+    @Test func testExportCurrentGameEmptyPath() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+        let exported = PGNExportService.exportCurrentGame(path: [], databaseView: databaseView)
+        #expect(exported.isEmpty)
+    }
+
+    @Test func testExportCurrentGameSingleNode() {
+        let database = Database(testDatabaseData: DatabaseData())
+        let databaseView = DatabaseView.full(database: database)
+        let exported = PGNExportService.exportCurrentGame(path: [1], databaseView: databaseView)
+        #expect(exported.isEmpty)
+    }
+
     // MARK: - Database without fenId=1
 
     @Test func testExportWithoutFenId1() {
@@ -254,7 +292,7 @@ struct PGNExportTests {
         // DatabaseData() creates empty data with no fenObjects — fenId=1 doesn't exist
         // But DatabaseStorage.createEmptyDatabase() creates fenId=1
         // With empty DatabaseData, getFenObjectUnfiltered(1) returns nil → empty
-        let exported = PGNExportService.exportPGN(databaseView: databaseView, rootFenId: 1)
+        let exported = PGNExportService.exportCurrentDatabaseView(databaseView: databaseView, rootFenId: 1)
         #expect(exported.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- 将原有的单一"导出PGN"拆分为两个菜单项："导出所有变着PGN..."和"导出当前棋局PGN..."
- 重命名 `exportPGN` 系列方法为 `exportPGNCurrentDatabaseView`，新增 `exportPGNCurrentGame` 系列方法
- 新增 `PGNExportService.exportCurrentGame(path:databaseView:)` 用于导出单条路径
- 新增 3 个测试覆盖 `exportCurrentGame`（线性路径、空路径、单节点）

Closes #62

## Test plan
- [x] 所有现有 PGNExportTests 通过（方法重命名后）
- [x] 新增 testExportCurrentGameLinearPath 通过
- [x] 新增 testExportCurrentGameEmptyPath 通过
- [x] 新增 testExportCurrentGameSingleNode 通过
- [x] 全量测试套件通过
- [x] 手动验证：macOS 菜单栏 → 文件 → 两个导出选项均可用
- [x] 手动验证："导出所有变着PGN..."导出所有路径
- [x] 手动验证："导出当前棋局PGN..."仅导出当前棋局主线

🤖 Generated with [Claude Code](https://claude.com/claude-code)