### PR TITLE
修复实战列表缓存键导致前进一步变慢

### DIFF
--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -24,7 +24,7 @@ class Session: ObservableObject {
     private var _cachedRealGames: [GameObject] = []
     private var _cachedHasMoreRealGames: Bool = false
     private var _cachedRealGamesFenId: Int = -1
-    private var _cachedRealGamesDataVersion: Bool = false
+    private var _cachedRealGamesDataVersion: Int = -1
 
     // databaseDirty 现在通过 databaseView.isDirty 访问
     var databaseDirty: Bool {
@@ -176,7 +176,7 @@ class Session: ObservableObject {
     /// 结果按 currentFenId 和 dataChanged 缓存，避免每次访问都重新计算
     var relatedRealGamesForCurrentFen: [GameObject] {
         let fenId = self.currentFenId
-        let dataVersion = self.dataChanged
+        let dataVersion = databaseView.dataVersion
 
         // 缓存命中：fenId 和数据版本都未变化
         if fenId == _cachedRealGamesFenId && dataVersion == _cachedRealGamesDataVersion {


### PR DESCRIPTION
## Summary
- 将 `relatedRealGamesForCurrentFen` 的缓存版本键从 `self.dataChanged`（Bool toggle）改为 `databaseView.dataVersion`（递增 Int）
- 修复前进/后退每步缓存都不命中、重复执行 `computeRelatedRealGames()` 的性能问题

Closes #65

## Test plan
- [x] RelatedRealGamesTests 全部通过
- [x] 完整测试套件通过
- [ ] 手动验证前进一步的响应速度恢复正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)