### PR TITLE
增加 Toggle 控制实战列表的显示与隐藏

### DIFF
--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -175,6 +175,8 @@ class Session: ObservableObject {
     /// 获取包含当前局面的实战对局列表，按日期降序排列
     /// 结果按 currentFenId 和 dataChanged 缓存，避免每次访问都重新计算
     var relatedRealGamesForCurrentFen: [GameObject] {
+        guard sessionData.showRealGameList else { return [] }
+
         let fenId = self.currentFenId
         let dataVersion = databaseView.dataVersion
 
@@ -193,6 +195,7 @@ class Session: ObservableObject {
 
     /// 是否有更多相关实战（超过显示限制）
     var hasMoreRelatedRealGames: Bool {
+        guard sessionData.showRealGameList else { return false }
         // 确保缓存已计算
         _ = relatedRealGamesForCurrentFen
         return _cachedHasMoreRealGames
@@ -498,6 +501,10 @@ class Session: ObservableObject {
 
     var showAllNextMoves: Bool {
         sessionData.showAllNextMoves
+    }
+
+    var showRealGameList: Bool {
+        sessionData.showRealGameList
     }
 
     var isCommentEditing: Bool {
@@ -1026,6 +1033,11 @@ extension Session {
 
     func toggleShowAllNextMoves() {
         sessionData.showAllNextMoves.toggle()
+        notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
+    }
+
+    func toggleShowRealGameList() {
+        sessionData.showRealGameList.toggle()
         notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
     }
 

--- a/XiangqiNotebook/Models/SessionData.swift
+++ b/XiangqiNotebook/Models/SessionData.swift
@@ -13,6 +13,7 @@ class SessionData: Codable {
     var currentMode: AppMode = .normal
     var showPath: Bool = true
     var showAllNextMoves: Bool = false
+    var showRealGameList: Bool = false
     var autoExtendGameWhenPlayingBoardFen: Bool = true
     var isCommentEditing: Bool = false
     var focusedPracticeGamePath: [Int]? = nil
@@ -45,6 +46,7 @@ class SessionData: Codable {
         case currentMode = "current_mode"
         case showPath = "show_path"
         case showAllNextMoves = "show_all_next_moves"
+        case showRealGameList = "show_real_game_list"
         case autoExtendGameWhenPlayingBoardFen = "auto_extend_game_when_playing_board_fen"
         case isCommentEditing = "is_comment_editing"
         case focusedPracticeGamePath = "focused_practice_game_path"
@@ -70,6 +72,7 @@ class SessionData: Codable {
         canNavigateBeforeLockedStep = try container.decode(Bool.self, forKey: .canNavigateBeforeLockedStep)
         showPath = try container.decode(Bool.self, forKey: .showPath)
         showAllNextMoves = try container.decodeIfPresent(Bool.self, forKey: .showAllNextMoves) ?? false
+        showRealGameList = try container.decodeIfPresent(Bool.self, forKey: .showRealGameList) ?? false
         autoExtendGameWhenPlayingBoardFen = try container.decode(Bool.self, forKey: .autoExtendGameWhenPlayingBoardFen)
         isCommentEditing = try container.decode(Bool.self, forKey: .isCommentEditing)
         focusedPracticeGamePath = try container.decodeIfPresent([Int].self, forKey: .focusedPracticeGamePath)
@@ -102,6 +105,7 @@ class SessionData: Codable {
         try container.encode(canNavigateBeforeLockedStep, forKey: .canNavigateBeforeLockedStep)
         try container.encode(showPath, forKey: .showPath)
         try container.encode(showAllNextMoves, forKey: .showAllNextMoves)
+        try container.encode(showRealGameList, forKey: .showRealGameList)
         try container.encode(autoExtendGameWhenPlayingBoardFen, forKey: .autoExtendGameWhenPlayingBoardFen)
         try container.encode(isCommentEditing, forKey: .isCommentEditing)
         try container.encodeIfPresent(focusedPracticeGamePath, forKey: .focusedPracticeGamePath)

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -58,6 +58,7 @@ class ActionDefinitions {
         case queryEngineScore  // 手动触发引擎深度评估
         case quickEngineScore  // 快速估分（3秒限时）
         case queryAllEngineScores  // 搜索本对局每一步的引擎分数
+        case quickAllEngineScores  // 快速估分本局所有局面
 
         // toggles
         case setFilterNone

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -78,6 +78,7 @@ class ActionDefinitions {
         case togglePracticeMode  // 新增：练习模式按钮
         case toggleShowPath  // 新增：显示路径按钮
         case toggleShowAllNextMoves  // 新增：显示所有下一步按钮
+        case toggleShowRealGameList  // 新增：显示实战列表按钮
         case toggleBookmark  // 新增：显示路径按钮
         case toggleIsCommentEditing
         case toggleAllowAddingNewMoves  // 新增：允许增加新走法

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -539,6 +539,19 @@ class ViewModel: ObservableObject {
           }
         )
 
+        // 显示实战列表 - 只在常规模式可用
+        actionDefinitions.registerToggleAction(
+          .toggleShowRealGameList,
+          text: "显示实战列表",
+          shortcuts: [.sequence(",t")],
+          supportedModes: [.normal],
+          isEnabled: { true },
+          isOn: { self.showRealGameList },
+          action: { newValue in
+            self.toggleShowRealGameList()
+          }
+        )
+
         // 书签功能 - 只在常规模式可用
         actionDefinitions.registerToggleAction(
           .toggleBookmark,
@@ -1890,6 +1903,7 @@ class ViewModel: ObservableObject {
     var currentAppMode: AppMode { session.currentAppMode }
     var showPath: Bool { session.showPath }
     var showAllNextMoves: Bool { session.showAllNextMoves }
+    var showRealGameList: Bool { session.showRealGameList }
     var isCommentEditing: Bool { session.isCommentEditing }
     var currentDataVersion: Int { session.currentDataVersion }
     var currentDataDirty: Bool { session.currentDataDirty }
@@ -2093,6 +2107,10 @@ class ViewModel: ObservableObject {
 
     func toggleShowAllNextMoves() {
         session.toggleShowAllNextMoves()
+    }
+
+    func toggleShowRealGameList() {
+        session.toggleShowRealGameList()
     }
 
     func setDataClean() {

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -290,7 +290,8 @@ class ViewModel: ObservableObject {
         #if os(macOS) && arch(arm64)
         actionDefinitions.registerAction(.quickEngineScore, text: "皮卡鱼快速估分", supportedModes: [.normal]) { Task { await self.quickEngineScore() } }
         actionDefinitions.registerAction(.queryEngineScore, text: "皮卡鱼深度评分", supportedModes: [.normal]) { Task { await self.queryEngineScore() } }
-        actionDefinitions.registerAction(.queryAllEngineScores, text: "本局查皮卡鱼", supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
+        actionDefinitions.registerAction(.queryAllEngineScores, text: "皮卡鱼深评本局", supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
+        actionDefinitions.registerAction(.quickAllEngineScores, text: "皮卡鱼快估本局", supportedModes: [.normal]) { Task { await self.quickAllEngineScores() } }
         #endif
         actionDefinitions.registerAction(.deleteScore, text: "删分", shortcuts: [.sequence(",D")], supportedModes: [.normal]) { self.updateFenScore(self.currentFenId, score: nil) }
         actionDefinitions.registerAction(.openYunku, text: "云库", shortcuts: [.single("y")], supportedModes: [.normal]) { self.openYunku() }
@@ -1414,6 +1415,87 @@ class ViewModel: ObservableObject {
                 }
             } catch {
                 print("[Pikafish] 全局评估 \(i)/\(totalSteps - 1) fenId=\(fenId) 失败: \(error.localizedDescription)")
+                break
+            }
+
+            let elapsedAfter = Date().timeIntervalSince(startTime)
+            let countAfter = evaluatedCount
+            let detailAfter = lastDetail
+            await MainActor.run {
+                self.batchEvalProgress = BatchEvalProgress(current: i + 1, total: totalSteps, evaluatedCount: countAfter, lastDetail: detailAfter, elapsedSeconds: elapsedAfter, isCompleted: false)
+            }
+        }
+
+        // 完成后显示最终结果
+        let finalElapsed = Date().timeIntervalSince(startTime)
+        let finalCount = evaluatedCount
+        let finalDetail = lastDetail
+        await MainActor.run {
+            self.batchEvalProgress = BatchEvalProgress(current: totalSteps, total: totalSteps, evaluatedCount: finalCount, lastDetail: finalDetail, elapsedSeconds: finalElapsed, isCompleted: true)
+        }
+    }
+
+    func quickAllEngineScores() async {
+        guard let service = ensurePikafishService() else { return }
+
+        isBatchEvaluating = true
+        batchEvalCancelled = false
+        defer { isBatchEvaluating = false }
+
+        let game = session.sessionData.currentGame2
+        let totalSteps = game.count
+        var evaluatedCount = 0
+        var lastDetail: String?
+        let startTime = Date()
+
+        await MainActor.run {
+            self.batchEvalProgress = BatchEvalProgress(current: 0, total: totalSteps, evaluatedCount: 0, lastDetail: nil, elapsedSeconds: nil, isCompleted: false)
+        }
+
+        // 从前往后搜索，利用 Hash 表复用加速后续局面
+        for i in 0..<totalSteps {
+            if batchEvalCancelled { break }
+
+            let fenId = game[i]
+
+            // 跳过已有快速引擎分数的局面
+            if Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.quickEngineKey) != nil {
+                let elapsed = Date().timeIntervalSince(startTime)
+                let count = evaluatedCount
+                let detail = lastDetail
+                await MainActor.run {
+                    self.batchEvalProgress = BatchEvalProgress(current: i + 1, total: totalSteps, evaluatedCount: count, lastDetail: detail, elapsedSeconds: elapsed, isCompleted: false)
+                }
+                continue
+            }
+
+            guard let fen = session.getFenForId(fenId) else { continue }
+
+            let elapsed = Date().timeIntervalSince(startTime)
+            let countBefore = evaluatedCount
+            let detailBefore = lastDetail
+            await MainActor.run {
+                self.batchEvalProgress = BatchEvalProgress(current: i, total: totalSteps, evaluatedCount: countBefore, lastDetail: detailBefore, elapsedSeconds: elapsed, isCompleted: false)
+            }
+
+            do {
+                var result = try await service.evaluatePosition(fen: fen, movetime: 3000)
+                if result == nil {
+                    try await Task.sleep(nanoseconds: 500_000_000)
+                    result = try await service.evaluatePosition(fen: fen, movetime: 3000)
+                }
+
+                if batchEvalCancelled { break }
+
+                if let result = result {
+                    lastDetail = Self.formatEvalDetail(result)
+                    await MainActor.run {
+                        self.session.updateEngineScore(fenId, score: result.score, engineKey: PikafishService.quickEngineKey)
+                    }
+                    evaluatedCount += 1
+                }
+            } catch {
+                print("[Pikafish] 快估本局 \(i)/\(totalSteps - 1) fenId=\(fenId) 失败: \(error.localizedDescription)")
                 break
             }
 

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -19,7 +19,7 @@ struct MacActionButtonsView: View {
                     .practiceRedOpening, .practiceBlackOpening,
                 ],
                 [
-                    .queryScore, .quickEngineScore, .queryEngineScore, .queryAllEngineScores,
+                    .queryScore, .quickEngineScore, .queryEngineScore, .quickAllEngineScores, .queryAllEngineScores,
                     .openYunku, .markPath, .referenceBoard, .browseGames, .importPGN,
                     .addToReview, .save,
                 ],

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -76,7 +76,7 @@ struct MacContentView: View {
                                 ModeSelectorView(viewModel: viewModel)
                                 TogglesView(viewModel: viewModel)
                                 BookmarkListView(viewModel: viewModel)
-                                if viewModel.currentAppMode == .normal {
+                                if viewModel.currentAppMode == .normal && viewModel.showRealGameList {
                                     RealGameListView(viewModel: viewModel)
                                 }
                             }

--- a/XiangqiNotebook/Views/RealGameListView.swift
+++ b/XiangqiNotebook/Views/RealGameListView.swift
@@ -32,6 +32,7 @@ struct RealGameListView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(8)
         .border(Color.gray)
     }

--- a/XiangqiNotebook/Views/TogglesView.swift
+++ b/XiangqiNotebook/Views/TogglesView.swift
@@ -50,6 +50,7 @@ struct BoardOperationTogglesView: View {
             MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
             MyToggle(viewModel: viewModel, actionKey: .toggleShowPath)
             MyToggle(viewModel: viewModel, actionKey: .toggleShowAllNextMoves)
+            MyToggle(viewModel: viewModel, actionKey: .toggleShowRealGameList)
             MyToggle(viewModel: viewModel, actionKey: .togglePracticeMode)
             MyToggle(viewModel: viewModel, actionKey: .toggleIsCommentEditing)
             MyToggle(viewModel: viewModel, actionKey: .toggleAllowAddingNewMoves)

--- a/XiangqiNotebook/Views/iOS/iPadContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPadContentView.swift
@@ -68,7 +68,7 @@ struct iPadContentView: View {
                             TogglesView(viewModel: viewModel)
                             BookmarkListView(viewModel: viewModel)
                                 .frame(maxHeight: .infinity)
-                            if viewModel.currentAppMode == .normal {
+                            if viewModel.currentAppMode == .normal && viewModel.showRealGameList {
                                 RealGameListView(viewModel: viewModel)
                             }
                         }

--- a/XiangqiNotebook/Views/iOS/iPhoneMoreButtonsView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneMoreButtonsView.swift
@@ -56,7 +56,7 @@ struct iPhoneMoreOptionsView: View {
                         }
                         .frame(maxWidth: .infinity)
 
-                        if viewModel.currentAppMode == .normal {
+                        if viewModel.currentAppMode == .normal && viewModel.showRealGameList {
                             HStack(spacing: 15) {
                                 iPhoneButton(viewModel: viewModel, actionKey: .showRealGameListIOS)
                             }

--- a/XiangqiNotebookTests/RelatedRealGamesTests.swift
+++ b/XiangqiNotebookTests/RelatedRealGamesTests.swift
@@ -65,6 +65,7 @@ struct RelatedRealGamesTests {
     /// 创建测试用的 Session
     private func createTestSession(database: Database) throws -> Session {
         let sessionData = SessionData()
+        sessionData.showRealGameList = true
         let databaseView = DatabaseView.full(database: database)
         return try Session(sessionData: sessionData, databaseView: databaseView)
     }


### PR DESCRIPTION
## Summary
- 添加 `showRealGameList` toggle（默认关闭），控制实战列表在 Mac/iPad/iPhone 上的可见性
- Toggle 关闭时跳过 `relatedRealGamesForCurrentFen` 计算，提升切换局面性能
- 修复实战列表为空时宽度未撑满的布局问题
- 快捷键 `,t`，位于棋盘操作 Toggle 区域

Closes #78

## Test plan
- [ ] Mac: Toggle 默认 off → 实战列表隐藏；打开 Toggle → 实战列表显示
- [ ] iPad: 同上验证右侧栏实战列表的显示/隐藏
- [ ] iPhone: Toggle off 时"更多"面板中不显示实战列表按钮
- [ ] 快捷键 `,t` 可正确切换
- [ ] Toggle 状态在重启后持久化
- [ ] 旧版 SessionData（无 showRealGameList 字段）可正常加载（默认 false）
- [ ] 全部单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)