### PR TITLE
增加皮卡鱼快速应招功能

### DIFF
--- a/XiangqiNotebook/Services/PikafishService.swift
+++ b/XiangqiNotebook/Services/PikafishService.swift
@@ -158,6 +158,25 @@ class PikafishService: @unchecked Sendable {
         let timeMs: Int?
         let hashfull: Int?
         let timedOut: Bool
+        let bestMove: String?
+    }
+
+    // MARK: - Best Move Parsing
+
+    /// 从 bestmove 响应行解析 UCI 着法
+    /// 解析 "bestmove h2e2 ponder ..." → "h2e2"
+    /// "bestmove (none)" → nil
+    static func parseBestMove(from response: String) -> String? {
+        for line in response.split(separator: "\n") {
+            let lineStr = String(line).trimmingCharacters(in: .whitespaces)
+            guard lineStr.hasPrefix("bestmove") else { continue }
+            let parts = lineStr.split(separator: " ")
+            guard parts.count >= 2 else { return nil }
+            let move = String(parts[1])
+            if move == "(none)" { return nil }
+            return move
+        }
+        return nil
     }
 
     // MARK: - Evaluation
@@ -252,7 +271,8 @@ class PikafishService: @unchecked Sendable {
         print("[Pikafish] depth=\(lastDepth ?? "?") hashfull=\(lastHashfull ?? "?")/1000 time=\(timeStr) score=\(lastScore.map { String($0) } ?? "nil")\(timedOut ? " (timeout)" : "")")
 
         guard let score = lastScore else { return nil }
-        return EvaluationResult(score: score, depth: lastDepth, timeMs: timeMsInt, hashfull: hashfullInt, timedOut: timedOut)
+        let bestMove = Self.parseBestMove(from: response)
+        return EvaluationResult(score: score, depth: lastDepth, timeMs: timeMsInt, hashfull: hashfullInt, timedOut: timedOut, bestMove: bestMove)
     }
 
     // MARK: - UCI Communication

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -59,6 +59,7 @@ class ActionDefinitions {
         case quickEngineScore  // 快速估分（3秒限时）
         case queryAllEngineScores  // 搜索本对局每一步的引擎分数
         case quickAllEngineScores  // 快速估分本局所有局面
+        case pikafishQuickMove     // 皮卡鱼快速应招
 
         // toggles
         case setFilterNone

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -58,6 +58,7 @@ class ActionDefinitions {
         case queryEngineScore  // 手动触发引擎深度评估
         case quickEngineScore  // 快速估分（3秒限时）
         case queryAllEngineScores  // 搜索本对局每一步的引擎分数
+        case quickAllEngineScores  // 快速估分本局所有局面
 
         // toggles
         case setFilterNone

--- a/XiangqiNotebook/ViewModels/BoardUtils.swift
+++ b/XiangqiNotebook/ViewModels/BoardUtils.swift
@@ -86,6 +86,16 @@ enum XiangqiBoardUtils {
         return pieceCode.hasPrefix("b") ? piece.lowercased() : piece
     }
     
+    /// 将 UCI 着法（如 "h2e2"）应用到给定 FEN，返回新 FEN
+    static func getNewFenAfterUCIMove(uciMove: String, fen: String) -> String? {
+        guard uciMove.count == 4 else { return nil }
+        let chars = Array(uciMove)
+        let from = String(chars[0...1])
+        let to = String(chars[2...3])
+        let pieces = fenToPiecesBySquare(fen)
+        return getNewFenAfterMove(from: from, to: to, currentPieces: pieces)
+    }
+
     static func getNewFenAfterMove(from: String, to: String, currentPieces: [String: String]) -> String? {
         guard let movingPiece = currentPieces[from] else { return nil }
         

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -292,6 +292,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.queryEngineScore, text: "皮卡鱼深度评分", supportedModes: [.normal]) { Task { await self.queryEngineScore() } }
         actionDefinitions.registerAction(.queryAllEngineScores, text: "皮卡鱼深评本局", supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
         actionDefinitions.registerAction(.quickAllEngineScores, text: "皮卡鱼快估本局", supportedModes: [.normal]) { Task { await self.quickAllEngineScores() } }
+        actionDefinitions.registerAction(.pikafishQuickMove, text: "皮卡鱼快速应招", supportedModes: [.normal]) { Task { await self.pikafishQuickMove() } }
         #endif
         actionDefinitions.registerAction(.deleteScore, text: "删分", shortcuts: [.sequence(",D")], supportedModes: [.normal]) { self.updateFenScore(self.currentFenId, score: nil) }
         actionDefinitions.registerAction(.openYunku, text: "打开云库", shortcuts: [.single("y")], supportedModes: [.normal]) { self.openYunku() }
@@ -1334,6 +1335,62 @@ class ViewModel: ObservableObject {
             await MainActor.run { self.batchEvalProgress = nil }
             platformService.showWarningAlert(
                 title: "皮卡鱼快速估分失败",
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    func pikafishQuickMove() async {
+        guard session.allowAddingNewMoves else {
+            platformService.showWarningAlert(
+                title: "不允许增加新走法",
+                message: "请先打开【允许增加新走法】选项。"
+            )
+            return
+        }
+        let fenId = session.currentFenId
+        guard let fen = session.getFenForId(fenId) else { return }
+        guard let service = ensurePikafishService() else { return }
+
+        isBatchEvaluating = true
+        batchEvalCancelled = false
+        defer { isBatchEvaluating = false }
+
+        let startTime = Date()
+        await MainActor.run {
+            self.batchEvalProgress = BatchEvalProgress(current: 0, total: 1, evaluatedCount: 0, lastDetail: nil, elapsedSeconds: nil, isCompleted: false)
+        }
+
+        do {
+            if batchEvalCancelled { return }
+
+            if let result = try await service.evaluatePosition(fen: fen, movetime: 3000) {
+                if batchEvalCancelled { return }
+                let detail = Self.formatEvalDetail(result)
+                let elapsed = Date().timeIntervalSince(startTime)
+
+                await MainActor.run {
+                    // 保存评分
+                    session.updateEngineScore(fenId, score: result.score, engineKey: PikafishService.quickEngineKey)
+
+                    // 走出推荐着法，并保存新局面的估分（取反）
+                    if let uciMove = result.bestMove,
+                       let newFen = XiangqiBoardUtils.getNewFenAfterUCIMove(uciMove: uciMove, fen: fen) {
+                        _ = session.playNewBoardFen(newFen)
+                        session.updateEngineScore(session.currentFenId, score: -result.score, engineKey: PikafishService.quickEngineKey)
+                    }
+
+                    self.batchEvalProgress = BatchEvalProgress(current: 1, total: 1, evaluatedCount: 1, lastDetail: detail, elapsedSeconds: elapsed, isCompleted: true)
+                }
+            } else {
+                await MainActor.run {
+                    self.batchEvalProgress = nil
+                }
+            }
+        } catch {
+            await MainActor.run { self.batchEvalProgress = nil }
+            platformService.showWarningAlert(
+                title: "皮卡鱼应招失败",
                 message: error.localizedDescription
             )
         }

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -290,7 +290,8 @@ class ViewModel: ObservableObject {
         #if os(macOS) && arch(arm64)
         actionDefinitions.registerAction(.quickEngineScore, text: "皮卡鱼快速估分", supportedModes: [.normal]) { Task { await self.quickEngineScore() } }
         actionDefinitions.registerAction(.queryEngineScore, text: "皮卡鱼深度评分", supportedModes: [.normal]) { Task { await self.queryEngineScore() } }
-        actionDefinitions.registerAction(.queryAllEngineScores, text: "本局查皮卡鱼", supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
+        actionDefinitions.registerAction(.queryAllEngineScores, text: "皮卡鱼深评本局", supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
+        actionDefinitions.registerAction(.quickAllEngineScores, text: "皮卡鱼快估本局", supportedModes: [.normal]) { Task { await self.quickAllEngineScores() } }
         #endif
         actionDefinitions.registerAction(.deleteScore, text: "删分", shortcuts: [.sequence(",D")], supportedModes: [.normal]) { self.updateFenScore(self.currentFenId, score: nil) }
         actionDefinitions.registerAction(.openYunku, text: "云库", shortcuts: [.single("y")], supportedModes: [.normal]) { self.openYunku() }
@@ -1414,6 +1415,87 @@ class ViewModel: ObservableObject {
                 }
             } catch {
                 print("[Pikafish] 全局评估 \(i)/\(totalSteps - 1) fenId=\(fenId) 失败: \(error.localizedDescription)")
+                break
+            }
+
+            let elapsedAfter = Date().timeIntervalSince(startTime)
+            let countAfter = evaluatedCount
+            let detailAfter = lastDetail
+            await MainActor.run {
+                self.batchEvalProgress = BatchEvalProgress(current: i + 1, total: totalSteps, evaluatedCount: countAfter, lastDetail: detailAfter, elapsedSeconds: elapsedAfter, isCompleted: false)
+            }
+        }
+
+        // 完成后显示最终结果
+        let finalElapsed = Date().timeIntervalSince(startTime)
+        let finalCount = evaluatedCount
+        let finalDetail = lastDetail
+        await MainActor.run {
+            self.batchEvalProgress = BatchEvalProgress(current: totalSteps, total: totalSteps, evaluatedCount: finalCount, lastDetail: finalDetail, elapsedSeconds: finalElapsed, isCompleted: true)
+        }
+    }
+
+    func quickAllEngineScores() async {
+        guard let service = ensurePikafishService() else { return }
+
+        isBatchEvaluating = true
+        batchEvalCancelled = false
+        defer { isBatchEvaluating = false }
+
+        let game = session.sessionData.currentGame2
+        let totalSteps = game.count
+        var evaluatedCount = 0
+        var lastDetail: String?
+        let startTime = Date()
+
+        await MainActor.run {
+            self.batchEvalProgress = BatchEvalProgress(current: 0, total: totalSteps, evaluatedCount: 0, lastDetail: nil, elapsedSeconds: nil, isCompleted: false)
+        }
+
+        // 从前往后搜索，利用 Hash 表复用加速后续局面
+        for i in 0..<totalSteps {
+            if batchEvalCancelled { break }
+
+            let fenId = game[i]
+
+            // 跳过已有快速引擎分数的局面
+            if Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.quickEngineKey) != nil {
+                let elapsed = Date().timeIntervalSince(startTime)
+                let count = evaluatedCount
+                let detail = lastDetail
+                await MainActor.run {
+                    self.batchEvalProgress = BatchEvalProgress(current: i + 1, total: totalSteps, evaluatedCount: count, lastDetail: detail, elapsedSeconds: elapsed, isCompleted: false)
+                }
+                continue
+            }
+
+            guard let fen = session.getFenForId(fenId) else { continue }
+
+            let elapsed = Date().timeIntervalSince(startTime)
+            let countBefore = evaluatedCount
+            let detailBefore = lastDetail
+            await MainActor.run {
+                self.batchEvalProgress = BatchEvalProgress(current: i, total: totalSteps, evaluatedCount: countBefore, lastDetail: detailBefore, elapsedSeconds: elapsed, isCompleted: false)
+            }
+
+            do {
+                var result = try await service.evaluatePosition(fen: fen, movetime: 3000)
+                if result == nil {
+                    try await Task.sleep(nanoseconds: 500_000_000)
+                    result = try await service.evaluatePosition(fen: fen, movetime: 3000)
+                }
+
+                if batchEvalCancelled { break }
+
+                if let result = result {
+                    lastDetail = Self.formatEvalDetail(result)
+                    await MainActor.run {
+                        self.session.updateEngineScore(fenId, score: result.score, engineKey: PikafishService.quickEngineKey)
+                    }
+                    evaluatedCount += 1
+                }
+            } catch {
+                print("[Pikafish] 快估本局 \(i)/\(totalSteps - 1) fenId=\(fenId) 失败: \(error.localizedDescription)")
                 break
             }
 

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -17,11 +17,12 @@ struct MacActionButtonsView: View {
                     .nextVariant, .playRandomNextMove, .random,
                     .practiceNewGame, .reviewThisGame, .focusedPractice,
                     .practiceRedOpening, .practiceBlackOpening,
+                    .addToReview,
                 ],
                 [
-                    .queryScore, .quickEngineScore, .queryEngineScore, .quickAllEngineScores, .queryAllEngineScores,
-                    .openYunku, .markPath, .referenceBoard, .browseGames, .importPGN,
-                    .addToReview, .save,
+                    .queryScore, .openYunku, .pikafishQuickMove, .quickEngineScore, .queryEngineScore, .quickAllEngineScores, .queryAllEngineScores,
+                    .markPath, .referenceBoard, .browseGames, .importPGN,
+                    .save,
                 ],
             ]
         case .practice:

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -19,7 +19,7 @@ struct MacActionButtonsView: View {
                     .practiceRedOpening, .practiceBlackOpening,
                 ],
                 [
-                    .queryScore, .quickEngineScore, .queryEngineScore, .queryAllEngineScores,
+                    .queryScore, .quickEngineScore, .queryEngineScore, .quickAllEngineScores, .queryAllEngineScores,
                     .openYunku, .markPath, .referenceBoard, .browseGames, .importPGN,
                     .addToReview, .save,
                 ],

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -310,12 +310,14 @@ struct MacMenuCommands: Commands {
         // 分析 menu
         CommandMenu("分析") {
             menuButton(.queryScore)
+            menuButton(.openYunku)
+            menuButton(.pikafishQuickMove)
             menuButton(.quickEngineScore)
             menuButton(.queryEngineScore)
+            menuButton(.quickAllEngineScores)
             menuButton(.queryAllEngineScores)
             Divider()
             menuButton(.referenceBoard)
-            menuButton(.openYunku)
             menuButton(.searchCurrentMove)
             Divider()
             menuButton(.markPath)

--- a/XiangqiNotebookTests/PikafishServiceTests.swift
+++ b/XiangqiNotebookTests/PikafishServiceTests.swift
@@ -68,4 +68,61 @@ struct PikafishServiceTests {
         let score = PikafishService.parseScore(from: infoLine)
         #expect(score == 0)
     }
+
+    // MARK: - Best Move Parsing Tests
+
+    @Test func testParseBestMove_normal() {
+        let response = "info depth 18 score cp 35 nodes 123456\nbestmove h2e2 ponder b9c7"
+        let move = PikafishService.parseBestMove(from: response)
+        #expect(move == "h2e2")
+    }
+
+    @Test func testParseBestMove_noPonder() {
+        let response = "info depth 10 score cp 0\nbestmove e2e4"
+        let move = PikafishService.parseBestMove(from: response)
+        #expect(move == "e2e4")
+    }
+
+    @Test func testParseBestMove_none() {
+        let response = "bestmove (none)"
+        let move = PikafishService.parseBestMove(from: response)
+        #expect(move == nil)
+    }
+
+    @Test func testParseBestMove_noLine() {
+        let response = "info depth 18 score cp 35 nodes 123456"
+        let move = PikafishService.parseBestMove(from: response)
+        #expect(move == nil)
+    }
+}
+
+// MARK: - UCI Move to FEN Tests
+
+struct UCIMoveToFenTests {
+
+    @Test func testGetNewFenAfterUCIMove_initialPosition() {
+        let fen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r"
+        // 红方炮二平五: h2e2
+        let newFen = XiangqiBoardUtils.getNewFenAfterUCIMove(uciMove: "h2e2", fen: fen)
+        #expect(newFen != nil)
+        // 炮从 h2 移到 e2，黑方走
+        #expect(newFen!.hasSuffix(" b"))
+        // 验证原位置 h2 不再有炮，目标位置 e2 有炮
+        let pieces = XiangqiBoardUtils.fenToPiecesBySquare(newFen!)
+        #expect(pieces["h2"] == nil)
+        #expect(pieces["e2"] == "rC")
+    }
+
+    @Test func testGetNewFenAfterUCIMove_invalidLength() {
+        let fen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r"
+        let result = XiangqiBoardUtils.getNewFenAfterUCIMove(uciMove: "h2", fen: fen)
+        #expect(result == nil)
+    }
+
+    @Test func testGetNewFenAfterUCIMove_noPieceAtSource() {
+        let fen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r"
+        // e5 is empty
+        let result = XiangqiBoardUtils.getNewFenAfterUCIMove(uciMove: "e5e4", fen: fen)
+        #expect(result == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- 新增"皮卡鱼快速应招"按钮，一键获取引擎推荐着法（3秒限时）并自动走出
- 同时保存走前和走后局面的快速估分（走后取反）
- 前置检查"允许增加新走法"开关，避免浪费引擎计算
- PikafishService 新增 bestMove 解析，BoardUtils 新增 UCI move → FEN 转换
- 按钮和菜单布局调整：打开云库紧挨云库查分，加入复习库移至第一行，补充菜单项

Closes #69

## Test plan
- [x] bestmove 解析单元测试（正常/无 ponder/none/无 bestmove 行）
- [x] UCI move → FEN 转换单元测试（正常走子/无效长度/空位置）
- [x] 全量测试套件通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)