### PR TITLE
增加复习核对答案模式

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -60,6 +60,10 @@ class ViewModel: ObservableObject {
     @Published private(set) var reviewQueue: [(fenId: Int, srsData: SRSData)] = []
     @Published private(set) var currentReviewIndex = 0
 
+    // 检验模式状态
+    @Published private(set) var verificationItem: (fenId: Int, srsData: SRSData)?
+    var isInVerificationMode: Bool { verificationItem != nil }
+
     // 检查是否有任何 sheet 正在显示（用于禁用快捷键）
     var isAnySheetPresented: Bool {
         return showingBookmarkAlert ||
@@ -850,6 +854,7 @@ class ViewModel: ObservableObject {
         // 每次进入新条目时重置为隐藏，避免上一条目的手动开启影响下一条目
         session.sessionData.showPath = false
         session.sessionData.showAllNextMoves = false
+        session.sessionData.allowAddingNewMoves = false
     }
 
     /// 加载棋局（总是先切换到 Full 视图）
@@ -1788,13 +1793,9 @@ class ViewModel: ObservableObject {
            let customName = srsData.customName, !customName.isEmpty {
             return customName
         }
-        if let fenObj = session.databaseView.getFenObject(fenId),
+        if let fenObj = session.databaseView.getFenObjectUnfiltered(fenId),
            let comment = fenObj.comment, !comment.isEmpty {
             return comment
-        }
-        if let fenObj = session.databaseView.getFenObject(fenId) {
-            let fen = fenObj.fen
-            return String(fen.prefix(20))
         }
         return "fenId: \(fenId)"
     }
@@ -1825,11 +1826,32 @@ class ViewModel: ObservableObject {
         currentReviewIndex = 0
         if let first = dueItems.first, let gamePath = first.srsData.gamePath {
             loadReviewItem(gamePath)
+        } else if let first = reviewItemList.first, let gamePath = first.srsData.gamePath {
+            // 没有到期项时，加载第一个复习项以锁定
+            loadReviewItem(gamePath)
         }
     }
 
     /// 提交复习评分，前进到下一项
     func submitReviewRating(_ quality: ReviewQuality) {
+        if isInVerificationMode {
+            // 核对答案模式：提交评分后退出核对，继续复习流程
+            if let item = verificationItem {
+                session.submitReviewRating(fenId: item.fenId, quality: quality)
+            }
+            exitVerificationMode()
+            // 前进到下一项
+            if isReviewingInProgress {
+                currentReviewIndex += 1
+                if isReviewingInProgress {
+                    let nextItem = reviewQueue[currentReviewIndex]
+                    if let gamePath = nextItem.srsData.gamePath {
+                        loadReviewItem(gamePath)
+                    }
+                }
+            }
+            return
+        }
         guard isReviewingInProgress else { return }
         let item = reviewQueue[currentReviewIndex]
         session.submitReviewRating(fenId: item.fenId, quality: quality)
@@ -1860,6 +1882,31 @@ class ViewModel: ObservableObject {
         currentReviewIndex = 0
         setMode(.normal)
     }
+
+    // MARK: - 检验模式
+
+    /// 进入检验模式：导航到复习项，锁定但显示路径和着法，不更新 SRS 数据
+    func enterVerificationMode(fenId: Int, srsData: SRSData, gamePath: [Int]) {
+        verificationItem = (fenId: fenId, srsData: srsData)
+        session.unlockIfNeeded()
+        sessionManager.loadBookmark(gamePath)
+        session.lockAndHideAfterCurrentStep()
+        session.sessionData.showPath = true
+        session.sessionData.showAllNextMoves = true
+        session.sessionData.autoExtendGameWhenPlayingBoardFen = true
+        #if os(iOS)
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            showReviewModeIOS = true
+        }
+        #endif
+    }
+
+    /// 退出检验模式
+    func exitVerificationMode() {
+        verificationItem = nil
+        session.unlockIfNeeded()
+    }
+
     var currentGameMoveListDisplay: [MoveListItem] { session.currentGameMoveList }
     var currentGameVariantListDisplay: [(moveString: String, move: Move)] {
         session.currentGameVariantList.sorted { $0.moveString < $1.moveString }
@@ -1957,6 +2004,11 @@ class ViewModel: ObservableObject {
     var autoExtendGameWhenPlayingBoardFen: Bool { session.autoExtendGameWhenPlayingBoardFen }
     var gameStepLimitation: Int? { session.gameStepLimitation }
     var currentLockedStep: Int? { session.sessionData.lockedStep }
+    var lockedFenId: Int? {
+        guard let step = session.sessionData.lockedStep,
+              step < session.sessionData.currentGame2.count else { return nil }
+        return session.sessionData.currentGame2[step]
+    }
     func setGameStepLimitation(_ limit: Int?) { session.setGameStepLimitation(limit) }
 
     func isBadMove(_ move: Move) -> Bool { session.isBadMove(move) }
@@ -2139,6 +2191,9 @@ class ViewModel: ObservableObject {
     }
 
     func setMode(_ mode: AppMode) {
+        if isInVerificationMode {
+            exitVerificationMode()
+        }
         session.setMode(mode)
         if mode == .review {
             startReview()

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -56,7 +56,20 @@ struct MacContentView: View {
                     .frame(width: geometry.size.width * 0.2)
 
                     // 右侧区域
-                    if viewModel.isInReviewMode {
+                    if viewModel.isInVerificationMode {
+                        // 检验模式：检验面板 + 单项列表 + 棋盘操作（底部）
+                        VStack(spacing: 0) {
+                            ModeSelectorView(viewModel: viewModel)
+                            ReviewModeView(viewModel: viewModel)
+                            ScrollView {
+                                ReviewListView(viewModel: viewModel)
+                            }
+                            .border(Color.gray)
+                            .frame(maxHeight: .infinity)
+                            BoardOperationTogglesView(viewModel: viewModel)
+                        }
+                        .frame(width: geometry.size.width * 0.2)
+                    } else if viewModel.isInReviewMode {
                         // 复习模式：复习面板 + 复习库列表（填满） + 棋盘操作（底部）
                         VStack(spacing: 0) {
                             ModeSelectorView(viewModel: viewModel)

--- a/XiangqiNotebook/Views/ReviewListView.swift
+++ b/XiangqiNotebook/Views/ReviewListView.swift
@@ -3,20 +3,37 @@ import SwiftUI
 /// 复习库列表组件（macOS/iPad 共用）
 struct ReviewListView: View {
     @ObservedObject var viewModel: ViewModel
+    @State private var selectedFenId: Int?
     @State private var renamingFenId: Int?
     @State private var renameText: String = ""
 
+    private var displayItems: [(fenId: Int, srsData: SRSData)] {
+        if let item = viewModel.verificationItem {
+            return [(fenId: item.fenId, srsData: item.srsData)]
+        }
+        return viewModel.reviewItemList
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
-            Text("复习库")
+            HStack {
+                Text(viewModel.isInVerificationMode ? "核对答案" : "复习库")
+                if viewModel.isInVerificationMode {
+                    Spacer()
+                    Button("隐藏答案") {
+                        viewModel.exitVerificationMode()
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
 
-            if viewModel.reviewItemList.isEmpty {
+            if displayItems.isEmpty {
                 Text("暂无复习项")
                     .foregroundColor(.secondary)
                     .padding(.vertical, 4)
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(viewModel.reviewItemList, id: \.fenId) { item in
+                    ForEach(displayItems, id: \.fenId) { item in
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(viewModel.reviewItemDescription(fenId: item.fenId))
@@ -35,38 +52,54 @@ struct ReviewListView: View {
                         .padding(.vertical, 4)
                         .padding(.horizontal, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(item.fenId == viewModel.currentFenId ? Color.blue.opacity(0.2) : Color.clear)
+                        .background(item.fenId == selectedFenId ? Color.blue.opacity(0.2) : Color.clear)
                         .contentShape(Rectangle())
                         .onTapGesture {
+                            selectedFenId = item.fenId
                             if let gamePath = item.srsData.gamePath {
                                 viewModel.loadReviewItem(gamePath)
                             }
                         }
-                        .contextMenu {
+                        .contextMenu(viewModel.isInVerificationMode ? nil : ContextMenu {
                             Button {
+                                selectedFenId = item.fenId
                                 renameText = viewModel.reviewItemDescription(fenId: item.fenId)
                                 renamingFenId = item.fenId
                             } label: {
                                 Label("重命名", systemImage: "pencil")
                             }
                             Button {
+                                selectedFenId = item.fenId
                                 viewModel.reviewAgain(fenId: item.fenId)
                             } label: {
                                 Label("再次复习", systemImage: "arrow.counterclockwise")
                             }
+                            if let gamePath = item.srsData.gamePath {
+                                Button {
+                                    selectedFenId = item.fenId
+                                    viewModel.enterVerificationMode(fenId: item.fenId, srsData: item.srsData, gamePath: gamePath)
+                                } label: {
+                                    Label("核对答案", systemImage: "checkmark.circle")
+                                }
+                            }
                             Divider()
                             Button(role: .destructive) {
+                                selectedFenId = item.fenId
                                 viewModel.removeReviewItem(fenId: item.fenId)
                             } label: {
                                 Label("删除", systemImage: "trash")
                             }
-                        }
+                        })
                         Divider()
                     }
                 }
             }
         }
         .padding(8)
+        .onAppear { selectedFenId = viewModel.lockedFenId ?? displayItems.first?.fenId }
+        .onChange(of: viewModel.lockedFenId) { _, newValue in
+            if let newValue { selectedFenId = newValue }
+        }
         .alert("重命名复习项", isPresented: Binding(
             get: { renamingFenId != nil },
             set: { if !$0 { renamingFenId = nil } }

--- a/XiangqiNotebook/Views/iOS/iPadContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPadContentView.swift
@@ -54,7 +54,16 @@ struct iPadContentView: View {
                         // 模式选择器
                         ModeSelectorView(viewModel: viewModel)
 
-                        if viewModel.isInReviewMode {
+                        if viewModel.isInVerificationMode {
+                            // 检验模式：检验面板 + 单项列表 + 棋盘操作（底部）
+                            ReviewModeView(viewModel: viewModel)
+                            ScrollView {
+                                ReviewListView(viewModel: viewModel)
+                            }
+                            .border(Color.gray)
+                            .frame(maxHeight: .infinity)
+                            BoardOperationTogglesView(viewModel: viewModel)
+                        } else if viewModel.isInReviewMode {
                             // 复习模式：复习面板 + 复习库列表（填满） + 棋盘操作（底部）
                             ReviewModeView(viewModel: viewModel)
                             ScrollView {

--- a/XiangqiNotebook/Views/iOS/iPhoneReviewListView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneReviewListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct iPhoneReviewListView: View {
     @ObservedObject var viewModel: ViewModel
     @Binding var isPresented: Bool
+    @State private var selectedFenId: Int?
     @State private var renamingFenId: Int?
     @State private var renameText: String = ""
 
@@ -38,9 +39,10 @@ struct iPhoneReviewListView: View {
                                 .padding(.vertical, 8)
                                 .padding(.horizontal, 4)
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(item.fenId == viewModel.currentFenId ? Color.blue.opacity(0.1) : Color.clear)
+                                .background(item.fenId == selectedFenId ? Color.blue.opacity(0.1) : Color.clear)
                                 .contentShape(Rectangle())
                                 .onTapGesture {
+                                    selectedFenId = item.fenId
                                     if let gamePath = item.srsData.gamePath {
                                         viewModel.loadReviewItem(gamePath)
                                         isPresented = false
@@ -48,18 +50,30 @@ struct iPhoneReviewListView: View {
                                 }
                                 .contextMenu {
                                     Button {
+                                        selectedFenId = item.fenId
                                         renameText = viewModel.reviewItemDescription(fenId: item.fenId)
                                         renamingFenId = item.fenId
                                     } label: {
                                         Label("重命名", systemImage: "pencil")
                                     }
                                     Button {
+                                        selectedFenId = item.fenId
                                         viewModel.reviewAgain(fenId: item.fenId)
                                     } label: {
                                         Label("再次复习", systemImage: "arrow.counterclockwise")
                                     }
+                                    if let gamePath = item.srsData.gamePath {
+                                        Button {
+                                            selectedFenId = item.fenId
+                                            viewModel.enterVerificationMode(fenId: item.fenId, srsData: item.srsData, gamePath: gamePath)
+                                            isPresented = false
+                                        } label: {
+                                            Label("核对答案", systemImage: "checkmark.circle")
+                                        }
+                                    }
                                     Divider()
                                     Button(role: .destructive) {
+                                        selectedFenId = item.fenId
                                         viewModel.removeReviewItem(fenId: item.fenId)
                                     } label: {
                                         Label("删除", systemImage: "trash")
@@ -98,6 +112,10 @@ struct iPhoneReviewListView: View {
             }
         }
         .presentationDetents([.medium, .large])
+        .onAppear { selectedFenId = viewModel.lockedFenId ?? viewModel.reviewItemList.first?.fenId }
+        .onChange(of: viewModel.lockedFenId) { _, newValue in
+            if let newValue { selectedFenId = newValue }
+        }
     }
 
     private func dueStatusText(_ srsData: SRSData) -> String {

--- a/XiangqiNotebook/Views/iOS/iPhoneReviewModeView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneReviewModeView.swift
@@ -6,11 +6,21 @@ import SwiftUI
 struct iPhoneReviewModeView: View {
     @ObservedObject var viewModel: ViewModel
     @Binding var isPresented: Bool
+    @State private var selectedFenId: Int?
+
+    private var displayItems: [(fenId: Int, srsData: SRSData)] {
+        if let item = viewModel.verificationItem {
+            return [(fenId: item.fenId, srsData: item.srsData)]
+        }
+        return viewModel.reviewItemList
+    }
 
     var body: some View {
         NavigationView {
             VStack(alignment: .leading, spacing: 12) {
-                if viewModel.isReviewingInProgress {
+                if viewModel.isInVerificationMode {
+                    verificationView
+                } else if viewModel.isReviewingInProgress {
                     reviewInProgressView
                 } else if viewModel.isReviewComplete {
                     reviewCompleteView
@@ -25,7 +35,7 @@ struct iPhoneReviewModeView: View {
                     .font(.headline)
                     .padding(.horizontal)
 
-                if viewModel.reviewItemList.isEmpty {
+                if displayItems.isEmpty {
                     Text("暂无复习项")
                         .foregroundColor(.secondary)
                         .padding(.horizontal)
@@ -33,7 +43,7 @@ struct iPhoneReviewModeView: View {
                 } else {
                     ScrollView(showsIndicators: true) {
                         VStack(alignment: .leading, spacing: 0) {
-                            ForEach(viewModel.reviewItemList, id: \.fenId) { item in
+                            ForEach(displayItems, id: \.fenId) { item in
                                 HStack {
                                     VStack(alignment: .leading, spacing: 2) {
                                         Text(viewModel.reviewItemDescription(fenId: item.fenId))
@@ -51,9 +61,10 @@ struct iPhoneReviewModeView: View {
                                 }
                                 .padding(.vertical, 8)
                                 .padding(.horizontal)
-                                .background(item.fenId == viewModel.currentFenId ? Color.blue.opacity(0.1) : Color.clear)
+                                .background(item.fenId == selectedFenId ? Color.blue.opacity(0.1) : Color.clear)
                                 .contentShape(Rectangle())
                                 .onTapGesture {
+                                    selectedFenId = item.fenId
                                     if let gamePath = item.srsData.gamePath {
                                         viewModel.loadReviewItem(gamePath)
                                     }
@@ -64,7 +75,7 @@ struct iPhoneReviewModeView: View {
                     }
                 }
             }
-            .navigationTitle("复习模式")
+            .navigationTitle(viewModel.isInVerificationMode ? "检验模式" : "复习模式")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -75,6 +86,27 @@ struct iPhoneReviewModeView: View {
             }
         }
         .presentationDetents([.medium, .large])
+        .onAppear { selectedFenId = viewModel.lockedFenId ?? displayItems.first?.fenId }
+        .onChange(of: viewModel.lockedFenId) { _, newValue in
+            if let newValue { selectedFenId = newValue }
+        }
+    }
+
+    // MARK: - 检验中
+
+    private var verificationView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let item = viewModel.verificationItem {
+                Text(viewModel.reviewItemDescription(fenId: item.fenId))
+                    .lineLimit(2)
+                    .padding(.horizontal)
+            }
+            Button("隐藏答案") {
+                viewModel.exitVerificationMode()
+                isPresented = false
+            }
+            .padding(.horizontal)
+        }
     }
 
     // MARK: - 复习进行中


### PR DESCRIPTION
## Summary

- 复习库右键菜单增加「核对答案」选项，进入后显示路径和着法、锁定步骤、启用自动拓展，不更新 SRS 数据
- 核对答案模式下支持直接评分（忘了/困难/良好/简单）并自动退出核对、进入下一复习项
- 复习模式默认禁止增加新走法
- 复习列表项支持点击选中高亮，高亮基于锁定局面保持稳定
- 核对答案模式下隐藏右键菜单，列表标题改为「核对答案」并显示「隐藏答案」按钮
- 切换模式时自动退出核对答案状态
- 复习项描述使用 Unfiltered 查询避免筛选范围导致显示异常
- 进入复习模式时始终锁定并选中第一个复习项

Closes #82

## Test plan

- [x] macOS: 常规模式 → 进入复习模式 → 确认第一项被选中高亮且锁定
- [x] macOS: 复习库列表 → 右键某项 → 核对答案 → 确认路径和着法可见、锁定有效、列表只显示当前项
- [x] macOS: 核对答案模式下点击评分按钮 → 确认退出核对并进入下一复习项
- [x] macOS: 核对答案模式下切换到其他模式再回复习模式 → 确认进入正常复习流程
- [x] macOS: 复习模式走子后 → 确认列表高亮保持在当前复习项
- [ ] iPad: 同上验证
- [ ] iPhone: 复习库长按某项 → 核对答案 → 确认路径和着法可见 → 退出

🤖 Generated with [Claude Code](https://claude.com/claude-code)