### PR TITLE
补全键盘快捷键并修复序列匹配冲突 (#85)

### DIFF
--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -171,12 +171,16 @@ class ActionDefinitions {
     }
     
     // MARK: - 序列模式状态
-    
+
     var isInSequenceMode = false
     var pendingSequence: String = ""
-    
+
     private var sequenceTimer: Timer?
     private let sequenceTimeout: TimeInterval = 1.5
+    /// 当短匹配命中但仍有更长可能时暂存的候选；超时后执行
+    private var pendingMatchedActionKey: ActionKey?
+    /// 歧义匹配的等待时间，给用户输入后续字符的窗口
+    private let ambiguousMatchTimeout: TimeInterval = 0.3
     
     /// 定义操作和对应的快捷键 - 统一版本支持所有快捷键类型
     struct ActionInfo {
@@ -431,33 +435,45 @@ class ActionDefinitions {
     
     private func handleSequenceInput(_ character: Character) -> Bool {
         pendingSequence.append(character)
-        
-        // 检查是否有匹配的序列
-        let shortcutKey = ShortcutKey.sequence(pendingSequence)
-        if let actionKey = shortcutLookup[shortcutKey] {
-            // 完全匹配，执行动作
-            let success = executeAction(actionKey)
-            exitSequenceMode()
-            return success
-        }
-        
-        // 检查是否有以当前序列开头的更长序列
+
+        let exactKey = ShortcutKey.sequence(pendingSequence)
+        let exactMatch = shortcutLookup[exactKey]
+
         let hasLongerSequence = shortcutLookup.keys.contains { key in
             if case .sequence(let sequence) = key {
                 return sequence.hasPrefix(pendingSequence) && sequence.count > pendingSequence.count
             }
             return false
         }
-        
-        if hasLongerSequence {
-            // 重启超时计时器
-            resetSequenceTimer()
-            return true
-        } else {
-            // 没有匹配的序列，退出序列模式
+
+        if let actionKey = exactMatch {
+            if hasLongerSequence {
+                // 歧义：当前序列既能完全匹配又有更长可能，暂存候选并等待
+                pendingMatchedActionKey = actionKey
+                resetSequenceTimer(ambiguous: true)
+                return true
+            }
+            // 唯一匹配，立即执行
+            let success = executeAction(actionKey)
             exitSequenceMode()
-            return false
+            return success
         }
+
+        if hasLongerSequence {
+            // 当前不匹配但还有更长可能，继续等待
+            resetSequenceTimer(ambiguous: pendingMatchedActionKey != nil)
+            return true
+        }
+
+        // 当前序列不匹配且无更长可能：若有暂存的短匹配候选，则执行它
+        if let actionKey = pendingMatchedActionKey {
+            let success = executeAction(actionKey)
+            exitSequenceMode()
+            return success
+        }
+
+        exitSequenceMode()
+        return false
     }
     
     private func startSequenceMode(with character: Character) -> Bool {
@@ -479,16 +495,23 @@ class ActionDefinitions {
         return false
     }
     
-    private func resetSequenceTimer() {
+    private func resetSequenceTimer(ambiguous: Bool = false) {
         sequenceTimer?.invalidate()
-        sequenceTimer = Timer.scheduledTimer(withTimeInterval: sequenceTimeout, repeats: false) { [weak self] _ in
-            self?.exitSequenceMode()
+        let timeout = ambiguous ? ambiguousMatchTimeout : sequenceTimeout
+        sequenceTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+            guard let self = self else { return }
+            // 超时时若存在暂存候选，执行之
+            if let actionKey = self.pendingMatchedActionKey {
+                _ = self.executeAction(actionKey)
+            }
+            self.exitSequenceMode()
         }
     }
-    
+
     private func exitSequenceMode() {
         isInSequenceMode = false
         pendingSequence = ""
+        pendingMatchedActionKey = nil
         sequenceTimer?.invalidate()
         sequenceTimer = nil
     }

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -278,30 +278,34 @@ class ViewModel: ObservableObject {
 
         actionDefinitions.registerAction(.previousPath, text: "上局", textIPhone: "上局", shortcuts: [.single("p")], supportedModes: [.normal]) { self.goToPreviousPath() }
         actionDefinitions.registerAction(.nextPath, text: "下局", textIPhone: "下局", shortcuts: [.single("n")], supportedModes: [.normal]) { self.goToNextPath() }
+        #if os(macOS)
         actionDefinitions.registerAction(.random, text: "随机一局", shortcuts: [.sequence(",g")], supportedModes: [.normal]) { _ = self.makeRandomGame() }
+        #else
+        actionDefinitions.registerAction(.random, text: "随机一局", supportedModes: [.normal]) { _ = self.makeRandomGame() }
+        #endif
         actionDefinitions.registerAction(.reviewThisGame, text: "回顾本局", textIPhone: "回顾", shortcuts: [.single("R")], supportedModes: [.practice]) { self.reviewThisGame() }
         actionDefinitions.registerAction(.searchCurrentMove, text: "搜索此步", shortcuts: [.sequence(",/")], supportedModes: [.normal]) { self.showSearchResultsWindow() }
         actionDefinitions.registerAction(.referenceBoard, text: "参考棋谱", shortcuts: [.modified([.command], "x")], supportedModes: [.normal]) { self.showReferenceBoard() }
 
         actionDefinitions.registerAction(.practiceNewGame, text: "练习新局", textIPhone: "练习", shortcuts: [.single("P")], supportedModes: [.normal, .practice]) { self.practiceNewGame() }
         actionDefinitions.registerAction(.focusedPractice, text: "练习本局", textIPhone: "专练", shortcuts: [.single("Z")], supportedModes: [.normal, .practice]) { self.startFocusedPractice() }
-        actionDefinitions.registerAction(.practiceRedOpening, text: "练习红方开局", supportedModes: [.normal, .practice]) { self.practiceRedOpening() }
-        actionDefinitions.registerAction(.practiceBlackOpening, text: "练习黑方开局", supportedModes: [.normal, .practice]) { self.practiceBlackOpening() }
-        actionDefinitions.registerAction(.playRandomNextMove, text: "随机走子", textIPhone: "随机", shortcuts: [.sequence(",r")], supportedModes: [.practice]) { self.playRandomNextMove() }
-        actionDefinitions.registerAction(.hintNextMove, text: "提示", textIPhone: "提示", supportedModes: [.practice]) { self.playRandomNextMove() }
+        actionDefinitions.registerAction(.practiceRedOpening, text: "练习红方开局", shortcuts: [.sequence(",1")], supportedModes: [.normal, .practice]) { self.practiceRedOpening() }
+        actionDefinitions.registerAction(.practiceBlackOpening, text: "练习黑方开局", shortcuts: [.sequence(",2")], supportedModes: [.normal, .practice]) { self.practiceBlackOpening() }
+        actionDefinitions.registerAction(.playRandomNextMove, text: "随机走子", textIPhone: "随机", supportedModes: [.practice]) { self.playRandomNextMove() }
+        actionDefinitions.registerAction(.hintNextMove, text: "提示", textIPhone: "提示", shortcuts: [.single("?")], supportedModes: [.practice]) { self.playRandomNextMove() }
 
         actionDefinitions.registerAction(.queryScore, text: "云库查分", shortcuts: [.single("s")], supportedModes: [.normal]) { Task { await self.queryFenScore() } }
         #if os(macOS) && arch(arm64)
-        actionDefinitions.registerAction(.quickEngineScore, text: "皮卡鱼快速估分", supportedModes: [.normal]) { Task { await self.quickEngineScore() } }
-        actionDefinitions.registerAction(.queryEngineScore, text: "皮卡鱼深度评分", supportedModes: [.normal]) { Task { await self.queryEngineScore() } }
-        actionDefinitions.registerAction(.queryAllEngineScores, text: "皮卡鱼深评本局", supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
-        actionDefinitions.registerAction(.quickAllEngineScores, text: "皮卡鱼快估本局", supportedModes: [.normal]) { Task { await self.quickAllEngineScores() } }
-        actionDefinitions.registerAction(.pikafishQuickMove, text: "皮卡鱼快速应招", supportedModes: [.normal]) { Task { await self.pikafishQuickMove() } }
+        actionDefinitions.registerAction(.quickEngineScore, text: "皮卡鱼快速估分", shortcuts: [.sequence(",qs")], supportedModes: [.normal]) { Task { await self.quickEngineScore() } }
+        actionDefinitions.registerAction(.queryEngineScore, text: "皮卡鱼深度评分", shortcuts: [.sequence(",Qs")], supportedModes: [.normal]) { Task { await self.queryEngineScore() } }
+        actionDefinitions.registerAction(.queryAllEngineScores, text: "皮卡鱼深评本局", shortcuts: [.sequence(",Qa")], supportedModes: [.normal]) { Task { await self.queryAllEngineScores() } }
+        actionDefinitions.registerAction(.quickAllEngineScores, text: "皮卡鱼快估本局", shortcuts: [.sequence(",qa")], supportedModes: [.normal]) { Task { await self.quickAllEngineScores() } }
+        actionDefinitions.registerAction(.pikafishQuickMove, text: "皮卡鱼快速应招", shortcuts: [.single("M")], supportedModes: [.normal]) { Task { await self.pikafishQuickMove() } }
         #endif
         actionDefinitions.registerAction(.deleteScore, text: "删分", shortcuts: [.sequence(",D")], supportedModes: [.normal]) { self.updateFenScore(self.currentFenId, score: nil) }
         actionDefinitions.registerAction(.openYunku, text: "打开云库", shortcuts: [.single("y")], supportedModes: [.normal]) { self.openYunku() }
         actionDefinitions.registerAction(.deleteMove, text: "删招", shortcuts: [.sequence(",d")], supportedModes: [.normal]) { self.removeCurrentStep() }
-        actionDefinitions.registerAction(.removeMoveFromGame, text: "从局中删除此招", supportedModes: [.normal]) { self.removeMoveFromGame() }
+        actionDefinitions.registerAction(.removeMoveFromGame, text: "从局中删除此招", shortcuts: [.sequence(",k")], supportedModes: [.normal]) { self.removeMoveFromGame() }
         actionDefinitions.registerAction(.markPath, text: "标记路径", shortcuts: [.single("a")], supportedModes: [.normal]) { self.showMarkPathView = true }
 
         actionDefinitions.registerAction(.save, text: "保存", shortcuts: [.single("w")], supportedModes: ActionDefinitions.allModes) { self.saveToDefault() }
@@ -313,13 +317,13 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.inputGame, text: "录入棋局", shortcuts: [.sequence(",i")], supportedModes: [.normal]) { self.showingGameInputView = true }
         actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",fff")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
         actionDefinitions.registerAction(.importPGN, text: "导入PGN", shortcuts: [.sequence(",p")], supportedModes: [.normal]) { self.showingPGNImportSheet = true }
-        actionDefinitions.registerAction(.exportPGNCurrentDatabaseView, text: "导出所有变着PGN...", supportedModes: [.normal]) { self.exportPGNCurrentDatabaseView() }
-        actionDefinitions.registerAction(.exportPGNCurrentGame, text: "导出当前棋局PGN...", supportedModes: [.normal]) { self.exportPGNCurrentGame() }
+        actionDefinitions.registerAction(.exportPGNCurrentDatabaseView, text: "导出所有变着PGN...", shortcuts: [.sequence(",X")], supportedModes: [.normal]) { self.exportPGNCurrentDatabaseView() }
+        actionDefinitions.registerAction(.exportPGNCurrentGame, text: "导出当前棋局PGN...", shortcuts: [.sequence(",W")], supportedModes: [.normal]) { self.exportPGNCurrentGame() }
 
         actionDefinitions.registerAction(.copyFEN, text: "拷贝FEN", shortcuts: [.sequence(",f")]) { self.copyFenToClipboard() }
-        actionDefinitions.registerAction(.copyBoardText, text: "生成详细局面文本") { self.showingBoardTextView = true }
+        actionDefinitions.registerAction(.copyBoardText, text: "生成详细局面文本", shortcuts: [.sequence(",c")]) { self.showingBoardTextView = true }
         actionDefinitions.registerAction(.fix, text: "修复", shortcuts: [.sequence(",fix")], supportedModes: [.normal]) { self.session.recalculateGameStatistics() }
-        actionDefinitions.registerAction(.autoAddToOpening, text: "自动完善开局库", supportedModes: [.normal]) { self.performAutoAddToOpening() }
+        actionDefinitions.registerAction(.autoAddToOpening, text: "自动完善开局库", shortcuts: [.sequence(",O")], supportedModes: [.normal]) { self.performAutoAddToOpening() }
         actionDefinitions.registerAction(.jumpToNextOpeningGap, text: "跳转开局缺口", shortcuts: [.sequence(",o")], supportedModes: [.normal]) { self.jumpToNextOpeningGap() }
 
         actionDefinitions.registerAction(.showEditCommentIOS, text: "编辑评论", shortcuts: [.sequence(",e")], supportedModes: [.normal]) { self.showEditCommentIOS = true }
@@ -333,9 +337,15 @@ class ViewModel: ObservableObject {
                 self.session.addCurrentFenToReview()
             }
         }
+        #if os(macOS)
         actionDefinitions.registerAction(.showReviewList, text: "复习库列表", shortcuts: [.sequence(",v")]) { self.showingReviewListView = true }
+        actionDefinitions.registerAction(.showReviewListIOS, text: "复习库") { self.showReviewListIOS = true }
+        actionDefinitions.registerAction(.showRealGameListIOS, text: "实战") { self.showRealGameListIOS = true }
+        #else
+        actionDefinitions.registerAction(.showReviewList, text: "复习库列表") { self.showingReviewListView = true }
         actionDefinitions.registerAction(.showReviewListIOS, text: "复习库", shortcuts: [.sequence(",v")]) { self.showReviewListIOS = true }
         actionDefinitions.registerAction(.showRealGameListIOS, text: "实战", shortcuts: [.sequence(",g")]) { self.showRealGameListIOS = true }
+        #endif
       
         actionDefinitions.registerToggleAction(
           .setFilterNone,
@@ -396,6 +406,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerToggleAction(
           .toggleFilterSpecificGame,
           text: "只筛选特定棋局",
+          shortcuts: [.single("5")],
           isEnabled: { self.session.sessionData.specificGameId != nil },
           isOn: { self.currentFilters.contains(Session.filterSpecificGame) },
           action: { _ in self.toggleFilterSpecificGame() }
@@ -404,6 +415,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerToggleAction(
           .toggleFilterSpecificBook,
           text: "只筛选特定棋书",
+          shortcuts: [.single("6")],
           isEnabled: { self.session.sessionData.specificBookId != nil },
           isOn: { self.currentFilters.contains(Session.filterSpecificBook) },
           action: { _ in self.toggleFilterSpecificBook() }
@@ -464,7 +476,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerToggleAction(
           .toggleCanNavigateBeforeLockedStep,
           text: "锁定区域可以前进后退",
-          shortcuts: [.sequence(",n")],
+          shortcuts: [.sequence(",N")],
           isEnabled: { self.isAnyMoveLocked },
           isOn: { self.canNavigateBeforeLockedStep },
           action: { newValue in
@@ -510,7 +522,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerToggleAction(
           .togglePracticeMode,
           text: "练习模式",
-          shortcuts: [.sequence(",p")],
+          shortcuts: [.sequence(",P")],
           isEnabled: { true },
           isOn: { self.session.sessionData.currentMode == .practice },
           action: { newValue in
@@ -591,6 +603,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerToggleAction(
           .toggleAllowAddingNewMoves,
           text: "允许增加新走法",
+          shortcuts: [.single("A")],
           isEnabled: { self.session.canToggleAllowAddingNewMoves },
           isOn: { self.session.allowAddingNewMoves },
           action: { _ in self.session.toggleAllowAddingNewMoves() }

--- a/XiangqiNotebookTests/ActionDefinitionsTests.swift
+++ b/XiangqiNotebookTests/ActionDefinitionsTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import XiangqiNotebook
+
+@MainActor
+struct ActionDefinitionsTests {
+
+    @Test
+    func sequenceWithoutLongerMatchExecutesImmediately() {
+        var executed = ""
+        let ad = ActionDefinitions()
+        ad.registerAction(.deleteMove, text: "t", shortcuts: [.sequence(",d")]) {
+            executed = "d"
+        }
+        _ = ad.handleKeyDown(character: ",")
+        _ = ad.handleKeyDown(character: "d")
+        #expect(executed == "d")
+        #expect(ad.isInSequenceMode == false)
+    }
+
+    @Test
+    func ambiguousShortMatchYieldsToLongerInput() {
+        var executed = ""
+        let ad = ActionDefinitions()
+        ad.registerAction(.copyFEN, text: "short", shortcuts: [.sequence(",f")]) {
+            executed = "f"
+        }
+        ad.registerAction(.browseGames, text: "long", shortcuts: [.sequence(",fff")]) {
+            executed = "fff"
+        }
+        _ = ad.handleKeyDown(character: ",")
+        _ = ad.handleKeyDown(character: "f")
+        // Short match registered as pending; not yet executed
+        #expect(executed == "")
+        _ = ad.handleKeyDown(character: "f")
+        _ = ad.handleKeyDown(character: "f")
+        #expect(executed == "fff")
+        #expect(ad.isInSequenceMode == false)
+    }
+
+    @Test
+    func ambiguousShortMatchExecutesAfterTimeout() {
+        var executed = ""
+        let ad = ActionDefinitions()
+        ad.registerAction(.copyFEN, text: "short", shortcuts: [.sequence(",f")]) {
+            executed = "f"
+        }
+        ad.registerAction(.browseGames, text: "long", shortcuts: [.sequence(",fff")]) {
+            executed = "fff"
+        }
+        _ = ad.handleKeyDown(character: ",")
+        _ = ad.handleKeyDown(character: "f")
+        #expect(executed == "")
+        // Drive RunLoop past ambiguous timeout (300ms) so the timer fires
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
+        #expect(executed == "f")
+        #expect(ad.isInSequenceMode == false)
+    }
+
+    @Test
+    func longerSequenceUnreachableWithoutAmbiguityHandling_isNowReachable() {
+        // Regression guard: previously ,fix was unreachable because ,f executed first.
+        var executed = ""
+        let ad = ActionDefinitions()
+        ad.registerAction(.copyFEN, text: "short", shortcuts: [.sequence(",f")]) {
+            executed = "f"
+        }
+        ad.registerAction(.fix, text: "long", shortcuts: [.sequence(",fix")]) {
+            executed = "fix"
+        }
+        _ = ad.handleKeyDown(character: ",")
+        _ = ad.handleKeyDown(character: "f")
+        _ = ad.handleKeyDown(character: "i")
+        _ = ad.handleKeyDown(character: "x")
+        #expect(executed == "fix")
+    }
+
+    @Test
+    func nonMatchingFollowupExecutesPendingShortMatch() {
+        // Typing ",f" then a non-matching character should execute copyFEN
+        // (no longer prefix matches ",fX").
+        var executed = ""
+        let ad = ActionDefinitions()
+        ad.registerAction(.copyFEN, text: "short", shortcuts: [.sequence(",f")]) {
+            executed = "f"
+        }
+        ad.registerAction(.browseGames, text: "long", shortcuts: [.sequence(",fff")]) {
+            executed = "fff"
+        }
+        _ = ad.handleKeyDown(character: ",")
+        _ = ad.handleKeyDown(character: "f")
+        _ = ad.handleKeyDown(character: "z")  // not a continuation of ,f
+        #expect(executed == "f")
+    }
+}


### PR DESCRIPTION
## Summary
- 给 16 个此前缺少快捷键的动作补充快捷键（提示、PGN 导入导出、皮卡鱼引擎五项、特定棋局/棋书筛选、允许增加新走法等）
- 修复 sequence 匹配的歧义问题：短匹配命中且仍有更长可能时启动 300ms 短超时窗口，使 `,fff` / `,fix` 等长序列重新可达
- 修复 5 处同名 sequence 重复注册导致的覆盖：`,p` / `,r` / `,n` / `,v` / `,g`
- 新增 `ActionDefinitionsTests`，覆盖 sequence 歧义解析的 5 种典型场景

Closes #85

## 主要快捷键调整

| Sequence | 调整 |
|---|---|
| `,p` | importPGN（之前被 togglePracticeMode 覆盖） |
| `,P` | togglePracticeMode（新位置） |
| `,n` | toggleShowAllNextMoves |
| `,N` | toggleCanNavigateBeforeLockedStep（从 `,n` 移走） |
| `,r` | addToReview |
| `?` | hintNextMove（与 playRandomNextMove 调同一函数） |
| `,v` / `,g` | 用 `#if os(macOS)` 平台分流 |

## Test plan
- [x] `xcodebuild test` 单元测试套件通过（除一个预存在失败 `testReviewItemDescription_NoNameNoComment_ReturnsFenPrefix`，已确认在 main 上同样失败）
- [x] 新增 5 个 ActionDefinitions 单元测试全部通过
- [x] 人工验证 `,p` 触发导入 PGN
- [x] 人工验证 `,fff` 触发棋局浏览器
- [x] 人工验证 `,fix` 触发修复
- [x] 人工验证 `,f` 短按拷贝 FEN 无明显延迟感
- [x] 人工验证 macOS 菜单栏正确展示新快捷键

🤖 Generated with [Claude Code](https://claude.com/claude-code)