### PR TITLE
ModeSelectorView 显示模式快捷键并支持直接切换 (#88)

### DIFF
--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -77,6 +77,9 @@ class ActionDefinitions {
         case toggleCanNavigateBeforeLockedStep  // 新增：导航锁定按钮
         case toggleAutoExtendGameWhenPlayingBoardFen  // 新增：自动拓展按钮
         case togglePracticeMode  // 新增：练习模式按钮
+        case setNormalMode  // 切换到常规模式
+        case setPracticeMode  // 切换到练习模式
+        case setReviewMode  // 切换到复习模式
         case toggleShowPath  // 新增：显示路径按钮
         case toggleShowAllNextMoves  // 新增：显示所有下一步按钮
         case toggleShowRealGameList  // 新增：显示实战列表按钮

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -530,6 +530,40 @@ class ViewModel: ObservableObject {
           }
         )
 
+        // 直接切换到指定模式（radio-button 语义）
+        actionDefinitions.registerToggleAction(
+          .setNormalMode,
+          text: "常规模式",
+          shortcuts: [.sequence(",Mn")],
+          isEnabled: { true },
+          isOn: { self.currentAppMode == .normal },
+          action: { newValue in
+            if newValue { self.setMode(.normal) }
+          }
+        )
+
+        actionDefinitions.registerToggleAction(
+          .setPracticeMode,
+          text: "练习模式",
+          shortcuts: [.sequence(",Mp")],
+          isEnabled: { true },
+          isOn: { self.currentAppMode == .practice },
+          action: { newValue in
+            if newValue { self.setMode(.practice) }
+          }
+        )
+
+        actionDefinitions.registerToggleAction(
+          .setReviewMode,
+          text: "复习模式",
+          shortcuts: [.sequence(",Mr")],
+          isEnabled: { true },
+          isOn: { self.currentAppMode == .review },
+          action: { newValue in
+            if newValue { self.setMode(.review) }
+          }
+        )
+
         // 路径相关 - 常规模式和复习模式可用
         actionDefinitions.registerToggleAction(
           .toggleShowPath,

--- a/XiangqiNotebook/Views/ModeSelectorView.swift
+++ b/XiangqiNotebook/Views/ModeSelectorView.swift
@@ -5,24 +5,18 @@ import SwiftUI
 struct ModeSelectorView: View {
     @ObservedObject var viewModel: ViewModel
 
+    private static let modeActionKeys: [ActionDefinitions.ActionKey] = [
+        .setNormalMode,
+        .setPracticeMode,
+        .setReviewMode,
+    ]
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("应用模式")
 
-            ForEach(AppMode.allCases, id: \.self) { mode in
-                HStack {
-                    Toggle(isOn: Binding(
-                        get: { viewModel.currentAppMode == mode },
-                        set: { isOn in
-                            if isOn {
-                                viewModel.setMode(mode)
-                            }
-                        }
-                    )) {
-                        Text(mode.displayName)
-                    }
-                    Spacer()
-                }
+            ForEach(Self.modeActionKeys, id: \.self) { key in
+                MyToggle(viewModel: viewModel, actionKey: key)
             }
         }
         .padding(8)

--- a/XiangqiNotebookTests/ViewModelTests.swift
+++ b/XiangqiNotebookTests/ViewModelTests.swift
@@ -753,6 +753,76 @@ struct ViewModelTests {
         #expect(vm.showAllNextMoves == false)
     }
 
+    // MARK: - 模式切换 Action
+
+    @Test func testSetNormalModeAction_SwitchesToNormal() {
+        let (vm, _) = createViewModel()
+        vm.session.togglePracticeMode()
+        #expect(vm.currentAppMode == .practice)
+
+        let info = vm.actionDefinitions.getToggleActionInfo(.setNormalMode)!
+        info.action(true)
+        #expect(vm.currentAppMode == .normal)
+    }
+
+    @Test func testSetPracticeModeAction_SwitchesToPractice() {
+        let (vm, _) = createViewModel()
+        #expect(vm.currentAppMode == .normal)
+
+        let info = vm.actionDefinitions.getToggleActionInfo(.setPracticeMode)!
+        info.action(true)
+        #expect(vm.currentAppMode == .practice)
+    }
+
+    @Test func testSetReviewModeAction_SwitchesToReviewAndStartsReview() {
+        let database = createTestDatabase()
+        let srs = SRSData(gamePath: [1, 2], nextReviewDate: Date.distantPast)
+        database.databaseData.reviewItems[1] = srs
+
+        let (vm, _) = createViewModel(database: database)
+        let info = vm.actionDefinitions.getToggleActionInfo(.setReviewMode)!
+        info.action(true)
+        #expect(vm.currentAppMode == .review)
+        #expect(!vm.reviewQueue.isEmpty)
+    }
+
+    @Test func testSetModeAction_IsOnReflectsCurrentMode() {
+        let (vm, _) = createViewModel()
+        let normalInfo = vm.actionDefinitions.getToggleActionInfo(.setNormalMode)!
+        let practiceInfo = vm.actionDefinitions.getToggleActionInfo(.setPracticeMode)!
+        let reviewInfo = vm.actionDefinitions.getToggleActionInfo(.setReviewMode)!
+
+        #expect(normalInfo.isOn() == true)
+        #expect(practiceInfo.isOn() == false)
+        #expect(reviewInfo.isOn() == false)
+
+        vm.session.togglePracticeMode()
+        #expect(normalInfo.isOn() == false)
+        #expect(practiceInfo.isOn() == true)
+        #expect(reviewInfo.isOn() == false)
+    }
+
+    @Test func testSetModeAction_ActionFalseDoesNotChangeMode() {
+        let (vm, _) = createViewModel()
+        #expect(vm.currentAppMode == .normal)
+
+        // toggle 设为 false 时不应触发模式切换（radio-button 语义）
+        let practiceInfo = vm.actionDefinitions.getToggleActionInfo(.setPracticeMode)!
+        practiceInfo.action(false)
+        #expect(vm.currentAppMode == .normal)
+    }
+
+    @Test func testSetModeAction_HasShortcutDisplay() {
+        let (vm, _) = createViewModel()
+        let normalInfo = vm.actionDefinitions.getToggleActionInfo(.setNormalMode)!
+        let practiceInfo = vm.actionDefinitions.getToggleActionInfo(.setPracticeMode)!
+        let reviewInfo = vm.actionDefinitions.getToggleActionInfo(.setReviewMode)!
+
+        #expect(normalInfo.shortcutsDisplayText == ",Mn")
+        #expect(practiceInfo.shortcutsDisplayText == ",Mp")
+        #expect(reviewInfo.shortcutsDisplayText == ",Mr")
+    }
+
     // MARK: - Navigation
 
     @Test func testStepForward_AdvancesPosition() {


### PR DESCRIPTION
## Summary

- 为常规模式、练习模式、复习模式分别新增专属快捷键 `,Mn` / `,Mp` / `,Mr`，每个模式可一键直达
- `ModeSelectorView` 改为复用 `MyToggle`，在每个模式名称后展示快捷键，与项目里其他 Toggle 显示风格一致
- 保留 `togglePracticeMode (,P)` 和 `BoardOperationTogglesView` 里的「练习模式」Toggle，向后兼容已有肌肉记忆

Closes #88

## 实现要点

- `ActionDefinitions` 新增三个 ActionKey：`setNormalMode` / `setPracticeMode` / `setReviewMode`
- `ViewModel.setupActionDefinitions()` 注册对应 toggle action，采用 radio-button 语义：仅 `newValue == true` 时调用 `setMode`，避免取消选中后陷入未定义状态
- `,M*` 是新前缀，与现有 `,m`（iPhone 书签）大小写不同，sequence lookup 大小写敏感故无冲突

## Test plan

- [x] 6 个新单元测试全部通过：触发 action 切换模式、`isOn` 反映当前模式、`action(false)` 不改模式、shortcut 显示文本正确
- [x] 完整 `xcodebuild test` 套件运行（仅 `testReviewItemDescription_NoNameNoComment_ReturnsFenPrefix` 失败，与 PR #87 一致是 main 分支既存的 flaky 测试，与本 PR 无关）
- [x] 手动验证：在 macOS 上左侧「应用模式」面板能看到三个模式的快捷键提示，并依次输入 `,Mn` / `,Mp` / `,Mr` 验证模式切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)