### PR TITLE
修复 reviewItemDescription 无名称无注释时未返回 fen 前缀

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1840,11 +1840,13 @@ class ViewModel: ObservableObject {
            let customName = srsData.customName, !customName.isEmpty {
             return customName
         }
-        if let fenObj = session.databaseView.getFenObjectUnfiltered(fenId),
-           let comment = fenObj.comment, !comment.isEmpty {
+        guard let fenObj = session.databaseView.getFenObjectUnfiltered(fenId) else {
+            return "fenId: \(fenId)"
+        }
+        if let comment = fenObj.comment, !comment.isEmpty {
             return comment
         }
-        return "fenId: \(fenId)"
+        return String(fenObj.fen.prefix(20))
     }
 
     // MARK: - 复习模式


### PR DESCRIPTION
## Summary
- `ViewModel.reviewItemDescription(fenId:)` 在复习项既无 customName 又无 comment 时，原本错误地返回 `\"fenId: X\"`，与单元测试 `testReviewItemDescription_NoNameNoComment_ReturnsFenPrefix` 的预期不符。
- 调整逻辑：当对应 `FenObject` 存在但既无名称又无注释时，返回 fen 字符串的前 20 个字符；只有在 fenId 找不到对应 `FenObject` 时才返回 `\"fenId: X\"` 作为兜底。

Closes #90

## Test plan
- [x] `xcodebuild test ... -only-testing:XiangqiNotebookTests/ViewModelTests` 通过
- [x] 全量测试套件 `xcodebuild test ... -only-testing:XiangqiNotebookTests` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)