### PR TITLE
加入复习库快捷键改为 R，招法列表标记从 v 改为 R

### DIFF
--- a/XiangqiNotebook/Models/GameOperations.swift
+++ b/XiangqiNotebook/Models/GameOperations.swift
@@ -6,7 +6,7 @@ struct MoveListItem {
     let notation: String            // 招法符号，如 "炮二平五", "马8进7"
     let redOpeningMarker: String    // 红方开局库标识，"r" 或空字符串
     let blackOpeningMarker: String  // 黑方开局库标识，"b" 或空字符串
-    let reviewMarker: String        // 复习库标识，"v" 或空字符串
+    let reviewMarker: String        // 复习库标识，"R" 或空字符串
     let markers: String             // 标记符号，如 "++++", "+++"（表示变着数量）
     let move: Move?                 // 对应的 Move 对象
 }
@@ -242,7 +242,7 @@ class GameOperations {
             let curFenObject = databaseView.getFenObject(curFenId)
             let redOpeningMarker = curFenObject?.isInRedOpening == true ? "r" : ""
             let blackOpeningMarker = curFenObject?.isInBlackOpening == true ? "b" : ""
-            let reviewMarker = databaseView.reviewItems[curFenId] != nil ? "v" : ""
+            let reviewMarker = databaseView.reviewItems[curFenId] != nil ? "R" : ""
 
             let moves = databaseView.moves(from: prevFenId)
             let movesLength = moves.count

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -283,7 +283,7 @@ class ViewModel: ObservableObject {
         #else
         actionDefinitions.registerAction(.random, text: "随机一局", supportedModes: [.normal]) { _ = self.makeRandomGame() }
         #endif
-        actionDefinitions.registerAction(.reviewThisGame, text: "回顾本局", textIPhone: "回顾", shortcuts: [.single("R")], supportedModes: [.practice]) { self.reviewThisGame() }
+        actionDefinitions.registerAction(.reviewThisGame, text: "回顾本局", textIPhone: "回顾", shortcuts: [.sequence(",r")], supportedModes: [.practice]) { self.reviewThisGame() }
         actionDefinitions.registerAction(.searchCurrentMove, text: "搜索此步", shortcuts: [.sequence(",/")], supportedModes: [.normal]) { self.showSearchResultsWindow() }
         actionDefinitions.registerAction(.referenceBoard, text: "参考棋谱", shortcuts: [.modified([.command], "x")], supportedModes: [.normal]) { self.showReferenceBoard() }
 
@@ -330,7 +330,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.showBookmarkListIOS, text: "书签", shortcuts: [.sequence(",m")]) { self.showIOSBookMarkListView = true }
         actionDefinitions.registerAction(.showMoreActionsIOS, text: "更多", shortcuts: [.sequence(",a")]) { self.showIOSMoreActionsView = true }
 
-        actionDefinitions.registerAction(.addToReview, text: "加入复习库", textIPhone: "复习+", shortcuts: [.sequence(",r")]) {
+        actionDefinitions.registerAction(.addToReview, text: "加入复习库", textIPhone: "复习+", shortcuts: [.single("R")]) {
             if self.session.isCurrentFenInReview {
                 self.session.removeReviewItem(fenId: self.session.currentFenId)
             } else {


### PR DESCRIPTION
## Summary
- 「加入复习库」快捷键由序列 `,r` 改为单键 `R`
- 「回顾本局」原单键 `R` 改为序列 `,r`，避免冲突
- 招法列表里复习库标记由 `v` 改为大写 `R`，与快捷键保持一致

Closes #89

## Test plan
- [x] 单元测试 `xcodebuild test -only-testing:XiangqiNotebookTests` 全部通过
- [x] macOS：normal 模式按 `R` 把当前局面加入/移出复习库
- [x] macOS：已加入复习库的局面在招法列表显示 `R` 标记
- [x] macOS：practice 模式按 `,r` 触发「回顾本局」
- [x] macOS：practice 模式直接按 `R` 触发「加入复习库」（不再触发「回顾本局」）
- [ ] iOS/iPad：按钮「复习+」和「回顾」点击仍能正常触发对应功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)