### PR TITLE
招法列表复习库标记和快捷键改为小写 v

### DIFF
--- a/XiangqiNotebook/Models/GameOperations.swift
+++ b/XiangqiNotebook/Models/GameOperations.swift
@@ -6,7 +6,7 @@ struct MoveListItem {
     let notation: String            // 招法符号，如 "炮二平五", "马8进7"
     let redOpeningMarker: String    // 红方开局库标识，"r" 或空字符串
     let blackOpeningMarker: String  // 黑方开局库标识，"b" 或空字符串
-    let reviewMarker: String        // 复习库标识，"R" 或空字符串
+    let reviewMarker: String        // 复习库标识，"v" 或空字符串
     let markers: String             // 标记符号，如 "++++", "+++"（表示变着数量）
     let move: Move?                 // 对应的 Move 对象
 }
@@ -242,7 +242,7 @@ class GameOperations {
             let curFenObject = databaseView.getFenObject(curFenId)
             let redOpeningMarker = curFenObject?.isInRedOpening == true ? "r" : ""
             let blackOpeningMarker = curFenObject?.isInBlackOpening == true ? "b" : ""
-            let reviewMarker = databaseView.reviewItems[curFenId] != nil ? "R" : ""
+            let reviewMarker = databaseView.reviewItems[curFenId] != nil ? "v" : ""
 
             let moves = databaseView.moves(from: prevFenId)
             let movesLength = moves.count

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -330,7 +330,7 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.showBookmarkListIOS, text: "书签", shortcuts: [.sequence(",m")]) { self.showIOSBookMarkListView = true }
         actionDefinitions.registerAction(.showMoreActionsIOS, text: "更多", shortcuts: [.sequence(",a")]) { self.showIOSMoreActionsView = true }
 
-        actionDefinitions.registerAction(.addToReview, text: "加入复习库", textIPhone: "复习+", shortcuts: [.single("R")]) {
+        actionDefinitions.registerAction(.addToReview, text: "加入复习库", textIPhone: "复习+", shortcuts: [.single("v")]) {
             if self.session.isCurrentFenInReview {
                 self.session.removeReviewItem(fenId: self.session.currentFenId)
             } else {


### PR DESCRIPTION
## Summary
- 招法列表里的复习库标记由 `R` 改回小写 `v`
- 「加入复习库」快捷键由 `R` 改为 `v`，与标记保持一致
- 「回顾本局」保持序列 `,r`，单键 `R` 现在空闲

## Test plan
- [x] 单元测试通过
- [x] 手动验证：按 `v` 触发「加入复习库」
- [x] 手动验证：已加入复习库的局面在招法列表显示 `v` 标记

🤖 Generated with [Claude Code](https://claude.com/claude-code)