### PR TITLE
修复设置时间戳弹窗中数字键被快捷键拦截 (#95)

### DIFF
--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -182,10 +182,16 @@ struct MacContentView: View {
 
             // 检查焦点是否在文本输入控件上
             if let firstResponder = NSApp.keyWindow?.firstResponder {
+                // NSTextField 的 first responder 实际是其 field editor（NSTextView, isFieldEditor=true），
+                // 例如 NSAlert 中的输入框。和 NSTextField 一视同仁：直接放行。
+                if let textView = firstResponder as? NSTextView, textView.isFieldEditor {
+                    return event
+                }
+
                 // 如果焦点在 TextField 上，不处理快捷键
                 if firstResponder is NSTextField { return event }
 
-                // 如果焦点在 TextEditor (NSTextView) 上
+                // 如果焦点在 TextEditor (NSTextView, 非 field editor) 上
                 if firstResponder is NSTextView {
                     if !viewModel.isCommentEditing {
                         // 评论编辑已关闭但焦点仍在 TextEditor，强制清除焦点


### PR DESCRIPTION
## Summary
- NSAlert 中 NSTextField 的 first responder 实际是其 field editor（`isFieldEditor=true` 的 NSTextView）。原 keyDown 监听器只识别 NSTextField/NSTextView 两类，field editor 落入 NSTextView 分支，又因 `isCommentEditing == false` 被清除焦点并把按键当快捷键派发，导致弹窗里无法输入数字。
- 在判断 NSTextView 前先识别 field editor 并直接放行事件，让所有由 NSTextField 衍生的输入框（包括 NSAlert 输入框）都能正常接收按键。

Closes #95

## Test plan
- [x] 全量单元测试通过 (`xcodebuild test ... -only-testing:XiangqiNotebookTests`)
- [x] 课程棋局右键 → "设置时间戳" → 弹窗中可正常输入数字（如 `15:30`）
- [x] 已设置后右键 → "编辑时间戳" → 同样可正常输入数字
- [x] 关闭弹窗后主界面数字键、字母快捷键仍正常工作
- [x] 评论编辑模式下 TextEditor 输入与 Escape 退出仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)