### PR TITLE
记录快捷键使用统计，支持查看和重置 (#98)

### DIFF
--- a/XiangqiNotebook/Models/ShortcutUsageStats.swift
+++ b/XiangqiNotebook/Models/ShortcutUsageStats.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// 快捷键使用统计：记录每个 ActionKey 通过快捷键触发的累计次数
+///
+/// 仅统计通过快捷键触发的次数，不统计按钮点击。
+/// 数据通过 UserDefaults 持久化，仅本地，不参与 iCloud 同步。
+class ShortcutUsageStats: ObservableObject {
+    static let shared = ShortcutUsageStats()
+
+    private let key: String
+    private let userDefaults: UserDefaults
+
+    /// ActionKey.rawValue → 累计触发次数
+    @Published private(set) var counts: [String: Int]
+
+    init(userDefaults: UserDefaults = .standard, key: String = "shortcutUsageStats") {
+        self.userDefaults = userDefaults
+        self.key = key
+        self.counts = (userDefaults.dictionary(forKey: key) as? [String: Int]) ?? [:]
+    }
+
+    /// 记录一次快捷键触发
+    func record(_ actionKey: ActionDefinitions.ActionKey) {
+        let rawKey = actionKey.rawValue
+        counts[rawKey, default: 0] += 1
+        userDefaults.set(counts, forKey: key)
+    }
+
+    /// 查询某个动作的累计触发次数
+    func count(for actionKey: ActionDefinitions.ActionKey) -> Int {
+        counts[actionKey.rawValue] ?? 0
+    }
+
+    /// 清空所有统计
+    func reset() {
+        counts = [:]
+        userDefaults.removeObject(forKey: key)
+    }
+}

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -94,6 +94,7 @@ class ActionDefinitions {
         case showBookmarkListIOS
         case showMoreActionsIOS
         case showEditCommentIOS
+        case showShortcutUsageStats  // 快捷键使用统计视图
     }
     
     // MARK: - 快捷键类型定义
@@ -174,6 +175,9 @@ class ActionDefinitions {
     }
     
     // MARK: - 序列模式状态
+
+    /// 快捷键触发动作时的记录回调；按钮点击不会触发此回调
+    var usageRecorder: ((ActionKey) -> Void)?
 
     var isInSequenceMode = false
     var pendingSequence: String = ""
@@ -551,6 +555,7 @@ class ActionDefinitions {
                 guard actionInfo.supportedModes.contains(currentMode) else { return false }
             }
             actionInfo.action()
+            usageRecorder?(actionKey)
             return true
         }
 
@@ -562,6 +567,7 @@ class ActionDefinitions {
             guard toggleInfo.isEnabled() else { return false }
             let currentState = toggleInfo.isOn()
             toggleInfo.action(!currentState)
+            usageRecorder?(actionKey)
             return true
         }
 

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -55,6 +55,7 @@ class ViewModel: ObservableObject {
     @Published var showReviewListIOS = false
     @Published var showReviewModeIOS = false
     @Published var showingBoardTextView = false
+    @Published var showingShortcutUsageStatsView = false
 
     // 复习模式状态
     @Published private(set) var reviewQueue: [(fenId: Int, srsData: SRSData)] = []
@@ -73,7 +74,8 @@ class ViewModel: ObservableObject {
                showingPGNImportSheet ||
                showMarkPathView ||
                showingReviewListView ||
-               showingBoardTextView
+               showingBoardTextView ||
+               showingShortcutUsageStatsView
     }
 
     // Global alert state
@@ -146,6 +148,9 @@ class ViewModel: ObservableObject {
         actionDefinitions.currentMode = { [weak self] in
             self?.currentAppMode ?? .normal
         }
+
+        // 7b. 记录快捷键使用次数（按钮点击不会触发）
+        actionDefinitions.usageRecorder = { ShortcutUsageStats.shared.record($0) }
 
         // 8. 异步构建实战反查表索引
         DispatchQueue.global(qos: .utility).async { [weak self] in
@@ -346,6 +351,8 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.showReviewListIOS, text: "复习库", shortcuts: [.sequence(",v")]) { self.showReviewListIOS = true }
         actionDefinitions.registerAction(.showRealGameListIOS, text: "实战", shortcuts: [.sequence(",g")]) { self.showRealGameListIOS = true }
         #endif
+
+        actionDefinitions.registerAction(.showShortcutUsageStats, text: "快捷键统计") { self.showingShortcutUsageStatsView = true }
       
         actionDefinitions.registerToggleAction(
           .setFilterNone,

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -150,6 +150,9 @@ struct MacContentView: View {
         .sheet(isPresented: $viewModel.showingBoardTextView) {
             BoardTextView(viewModel: viewModel)
         }
+        .sheet(isPresented: $viewModel.showingShortcutUsageStatsView) {
+            ShortcutUsageStatsView(viewModel: viewModel)
+        }
         .onChange(of: viewModel.isCommentEditing) { oldValue, newValue in
             // 当评论编辑状态从 true 变为 false 时，清除焦点
             if oldValue && !newValue {
@@ -337,6 +340,11 @@ struct MacMenuCommands: Commands {
             Divider()
             menuButton(.autoAddToOpening)
             menuButton(.jumpToNextOpeningGap)
+        }
+
+        // 帮助/诊断 menu 项
+        CommandGroup(after: .help) {
+            menuButton(.showShortcutUsageStats)
         }
 
         // 练习 menu

--- a/XiangqiNotebook/Views/ShortcutUsageStatsView.swift
+++ b/XiangqiNotebook/Views/ShortcutUsageStatsView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// 快捷键使用统计视图：按触发次数从多到少展示已记录的动作
+struct ShortcutUsageStatsView: View {
+    @ObservedObject var viewModel: ViewModel
+    @ObservedObject private var stats = ShortcutUsageStats.shared
+    @State private var showingResetConfirmation = false
+
+    /// (动作名, 快捷键文本, 次数)
+    private var rows: [(name: String, shortcut: String, count: Int)] {
+        let ad = viewModel.actionDefinitions
+        return stats.counts
+            .map { (rawKey, count) -> (name: String, shortcut: String, count: Int) in
+                if let actionKey = ActionDefinitions.ActionKey(rawValue: rawKey) {
+                    if let info = ad.getActionInfo(actionKey) {
+                        return (name: info.text, shortcut: info.shortcutsDisplayText ?? "-", count: count)
+                    }
+                    if let info = ad.getToggleActionInfo(actionKey) {
+                        return (name: info.text, shortcut: info.shortcutsDisplayText ?? "-", count: count)
+                    }
+                }
+                return (name: rawKey, shortcut: "-", count: count)
+            }
+            .sorted { $0.count > $1.count }
+    }
+
+    var body: some View {
+        #if os(macOS)
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(minWidth: 480, minHeight: 360)
+        .alert("重置统计？", isPresented: $showingResetConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("重置", role: .destructive) { stats.reset() }
+        } message: {
+            Text("此操作将清空所有快捷键使用统计，且无法撤销。")
+        }
+        #else
+        NavigationView {
+            content
+                .navigationTitle("快捷键统计")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("重置") { showingResetConfirmation = true }
+                            .disabled(stats.counts.isEmpty)
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("关闭") { viewModel.showingShortcutUsageStatsView = false }
+                    }
+                }
+        }
+        .alert("重置统计？", isPresented: $showingResetConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("重置", role: .destructive) { stats.reset() }
+        } message: {
+            Text("此操作将清空所有快捷键使用统计，且无法撤销。")
+        }
+        #endif
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack {
+            Text("快捷键使用统计").font(.headline)
+            Spacer()
+            Text("共 \(stats.counts.count) 个动作").foregroundColor(.secondary)
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if rows.isEmpty {
+            VStack {
+                Spacer()
+                Text("尚无快捷键使用记录").foregroundColor(.secondary)
+                Spacer()
+            }
+        } else {
+            List {
+                HStack {
+                    Text("动作").bold()
+                    Spacer()
+                    Text("快捷键").bold().frame(width: 100, alignment: .leading)
+                    Text("次数").bold().frame(width: 60, alignment: .trailing)
+                }
+                ForEach(rows, id: \.name) { row in
+                    HStack {
+                        Text(row.name)
+                        Spacer()
+                        Text(row.shortcut)
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .frame(width: 100, alignment: .leading)
+                        Text("\(row.count)")
+                            .font(.system(.body, design: .monospaced))
+                            .frame(width: 60, alignment: .trailing)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack {
+            Button("重置") { showingResetConfirmation = true }
+                .disabled(stats.counts.isEmpty)
+            Spacer()
+            Button("关闭") { viewModel.showingShortcutUsageStatsView = false }
+        }
+        .padding()
+    }
+}

--- a/XiangqiNotebook/Views/iOS/iPhoneContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneContentView.swift
@@ -79,6 +79,9 @@ struct iPhoneContentView: View {
         .sheet(isPresented: $viewModel.showReviewModeIOS) {
             iPhoneReviewModeView(viewModel: viewModel, isPresented: $viewModel.showReviewModeIOS)
         }
+        .sheet(isPresented: $viewModel.showingShortcutUsageStatsView) {
+            ShortcutUsageStatsView(viewModel: viewModel)
+        }
         .alert(viewModel.globalAlertTitle, isPresented: $viewModel.showingGlobalAlert) {
             Button("确定") { }
         } message: {

--- a/XiangqiNotebook/Views/iOS/iPhoneMoreButtonsView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneMoreButtonsView.swift
@@ -56,6 +56,11 @@ struct iPhoneMoreOptionsView: View {
                         }
                         .frame(maxWidth: .infinity)
 
+                        HStack(spacing: 15) {
+                            iPhoneButton(viewModel: viewModel, actionKey: .showShortcutUsageStats)
+                        }
+                        .frame(maxWidth: .infinity)
+
                         if viewModel.currentAppMode == .normal && viewModel.showRealGameList {
                             HStack(spacing: 15) {
                                 iPhoneButton(viewModel: viewModel, actionKey: .showRealGameListIOS)

--- a/XiangqiNotebookTests/ShortcutUsageStatsTests.swift
+++ b/XiangqiNotebookTests/ShortcutUsageStatsTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import Foundation
+@testable import XiangqiNotebook
+
+@MainActor
+struct ShortcutUsageStatsTests {
+
+    /// 隔离的 UserDefaults，避免测试污染真实数据
+    private func makeStats() -> (ShortcutUsageStats, UserDefaults, String) {
+        let suiteName = "ShortcutUsageStatsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let key = "shortcutUsageStats"
+        return (ShortcutUsageStats(userDefaults: defaults, key: key), defaults, suiteName)
+    }
+
+    @Test
+    func recordIncrementsCount() {
+        let (stats, _, _) = makeStats()
+        #expect(stats.count(for: .toStart) == 0)
+        stats.record(.toStart)
+        #expect(stats.count(for: .toStart) == 1)
+        stats.record(.toStart)
+        stats.record(.toStart)
+        #expect(stats.count(for: .toStart) == 3)
+    }
+
+    @Test
+    func recordIsPersisted() {
+        let suiteName = "ShortcutUsageStatsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let key = "shortcutUsageStats"
+
+        let stats1 = ShortcutUsageStats(userDefaults: defaults, key: key)
+        stats1.record(.copyFEN)
+        stats1.record(.copyFEN)
+
+        // 用同样的 UserDefaults 创建新实例，应能读出旧数据
+        let stats2 = ShortcutUsageStats(userDefaults: defaults, key: key)
+        #expect(stats2.count(for: .copyFEN) == 2)
+    }
+
+    @Test
+    func resetClearsAllCounts() {
+        let (stats, _, _) = makeStats()
+        stats.record(.stepBack)
+        stats.record(.stepForward)
+        #expect(stats.count(for: .stepBack) == 1)
+        stats.reset()
+        #expect(stats.count(for: .stepBack) == 0)
+        #expect(stats.count(for: .stepForward) == 0)
+        #expect(stats.counts.isEmpty)
+    }
+
+    @Test
+    func actionDefinitionsTriggersUsageRecorderOnShortcut() {
+        var recorded: [ActionDefinitions.ActionKey] = []
+        let ad = ActionDefinitions()
+        ad.usageRecorder = { recorded.append($0) }
+
+        var executed = false
+        ad.registerAction(.copyFEN, text: "copy", shortcuts: [.single("c")]) {
+            executed = true
+        }
+
+        // 通过快捷键触发
+        let handled = ad.handleKeyDown(character: "c")
+        #expect(handled == true)
+        #expect(executed == true)
+        #expect(recorded == [.copyFEN])
+    }
+
+    @Test
+    func actionDefinitionsTriggersUsageRecorderForToggle() {
+        var recorded: [ActionDefinitions.ActionKey] = []
+        let ad = ActionDefinitions()
+        ad.usageRecorder = { recorded.append($0) }
+
+        var toggleState = false
+        ad.registerToggleAction(
+            .toggleLock,
+            text: "lock",
+            shortcuts: [.single("L")],
+            isEnabled: { true },
+            isOn: { toggleState },
+            action: { toggleState = $0 }
+        )
+
+        let handled = ad.handleKeyDown(character: "L")
+        #expect(handled == true)
+        #expect(toggleState == true)
+        #expect(recorded == [.toggleLock])
+    }
+
+    @Test
+    func directButtonClickDoesNotTriggerUsageRecorder() {
+        // 按钮点击通过 ActionInfo.action() 直接调用，不经过 executeAction，故不记录
+        var recorded: [ActionDefinitions.ActionKey] = []
+        let ad = ActionDefinitions()
+        ad.usageRecorder = { recorded.append($0) }
+
+        var executed = false
+        ad.registerAction(.copyFEN, text: "copy", shortcuts: [.single("c")]) {
+            executed = true
+        }
+
+        // 模拟按钮点击：直接调用 action()
+        ad.getActionInfo(.copyFEN)?.action()
+
+        #expect(executed == true)
+        #expect(recorded.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `ShortcutUsageStats` 单例：UserDefaults 持久化每个 ActionKey 通过快捷键触发的累计次数（仅本机，不参与 iCloud）
- `ActionDefinitions.executeAction` 在动作/Toggle 成功后回调可选 `usageRecorder`；按钮点击直接调用 `ActionInfo.action()`，绕过 `executeAction`，故不计入——符合 issue 中'快捷键使用'的语义
- 新增 ActionKey `.showShortcutUsageStats` 弹出 `ShortcutUsageStatsView`，按次数从多到少展示动作名/快捷键文本/次数，提供重置入口
- 入口：Mac 通过 Help 菜单访问；iOS 通过'更多'页面新增按钮

Closes #98

## Test plan
- [x] 全量单元测试通过
- [x] 新增测试覆盖：递增、持久化、重置、快捷键路径触发 recorder、按钮点击不触发 recorder
- [x] 手工验证：使用一些快捷键后打开统计视图，看到对应动作的计数
- [x] 手工验证：点击'重置'后弹出确认，确认后统计清零
- [x] 手工验证：点击按钮（非快捷键）不会增加计数
- [x] 手工验证：重启 App 后统计仍存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)