### PR TITLE
练习模式记录走错的局面、错招、次数和时间 (#19)

### DIFF
--- a/XiangqiNotebook/Models/DatabaseData.swift
+++ b/XiangqiNotebook/Models/DatabaseData.swift
@@ -9,10 +9,12 @@ class DatabaseData: Codable {
     var bookObjects: [UUID: BookObject] = [:]
     var bookmarks: [[Int]: String] = [:]
     var reviewItems: [Int: SRSData] = [:]
+    /// 练习模式走错统计：fenId → 该局面下出现过的所有错招记录
+    var practiceMistakes: [Int: [PracticeMistakeRecord]] = [:]
     var myRealRedGameStatisticsByFenId: [Int: GameResultStatistics] = [:]
     var myRealBlackGameStatisticsByFenId: [Int: GameResultStatistics] = [:]
     var dataVersion: Int = 0
-    
+
     enum CodingKeys: String, CodingKey {
         case fenObjects2 = "fenObjects2"
         case moveObjects = "MoveObjects"
@@ -20,6 +22,7 @@ class DatabaseData: Codable {
         case bookObjects = "book_objects"
         case bookmarks
         case reviewItems = "review_items"
+        case practiceMistakes = "practice_mistakes"
         case myRealRedGameStatisticsByFenId = "my_real_red_game_statistics_by_fen_id"
         case myRealBlackGameStatisticsByFenId = "my_real_black_game_statistics_by_fen_id"
         case dataVersion = "data_version"
@@ -42,6 +45,7 @@ class DatabaseData: Codable {
         bookObjects = try container.decode([UUID: BookObject].self, forKey: .bookObjects)
         bookmarks = try container.decode([[Int]: String].self, forKey: .bookmarks)
         reviewItems = try container.decodeIfPresent([Int: SRSData].self, forKey: .reviewItems) ?? [:]
+        practiceMistakes = try container.decodeIfPresent([Int: [PracticeMistakeRecord]].self, forKey: .practiceMistakes) ?? [:]
         myRealRedGameStatisticsByFenId = try container.decode([Int: GameResultStatistics].self, forKey: .myRealRedGameStatisticsByFenId)
         myRealBlackGameStatisticsByFenId = try container.decode([Int: GameResultStatistics].self, forKey: .myRealBlackGameStatisticsByFenId)
         dataVersion = try container.decode(Int.self, forKey: .dataVersion)

--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -180,6 +180,16 @@ final class DatabaseView {
         database.databaseData.reviewItems
     }
 
+    /// 练习模式走错统计（按 DatabaseView 当前筛选范围过滤）
+    var practiceMistakes: [Int: [PracticeMistakeRecord]] {
+        database.databaseData.practiceMistakes.filter { containsFenId($0.key) }
+    }
+
+    /// 练习模式走错统计（不过滤，访问全量底层数据）
+    var practiceMistakesUnfiltered: [Int: [PracticeMistakeRecord]] {
+        database.databaseData.practiceMistakes
+    }
+
     var dataVersion: Int {
         database.databaseData.dataVersion
     }
@@ -499,6 +509,31 @@ final class DatabaseView {
     /// 更新复习项（nil 表示删除）
     func updateReviewItem(for fenId: Int, srsData: SRSData?) {
         database.databaseData.reviewItems[fenId] = srsData
+        markDirty()
+    }
+
+    /// 记录一次练习走错：在 fenId 处走出了 wrongFen
+    /// 同一 (fenId, wrongFen) 组合会累加 count，不会重复创建条目
+    func recordPracticeMistake(at fenId: Int, wrongFen: String, at date: Date = Date()) {
+        var records = database.databaseData.practiceMistakes[fenId] ?? []
+        if let idx = records.firstIndex(where: { $0.wrongFen == wrongFen }) {
+            records[idx].count += 1
+            records[idx].lastWrongAt = date
+        } else {
+            records.append(PracticeMistakeRecord(
+                wrongFen: wrongFen,
+                count: 1,
+                firstWrongAt: date,
+                lastWrongAt: date
+            ))
+        }
+        database.databaseData.practiceMistakes[fenId] = records
+        markDirty()
+    }
+
+    /// 清空所有练习错误统计
+    func resetPracticeMistakes() {
+        database.databaseData.practiceMistakes = [:]
         markDirty()
     }
 

--- a/XiangqiNotebook/Models/PracticeMistakeRecord.swift
+++ b/XiangqiNotebook/Models/PracticeMistakeRecord.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// 练习模式中一次走错的累计记录
+///
+/// 一个 fenId（走错时所在的源局面）可能对应多条不同的 PracticeMistakeRecord，
+/// 每一条对应一种"错招"——以走出的 wrongFen 区分。
+struct PracticeMistakeRecord: Codable, Equatable {
+    /// 用户走出的（错误）目标局面 FEN（标准化后的字符串）
+    var wrongFen: String
+    /// 该错招的累计走错次数
+    var count: Int
+    /// 首次走错的时间
+    var firstWrongAt: Date
+    /// 最近一次走错的时间
+    var lastWrongAt: Date
+
+    init(wrongFen: String, count: Int = 1, firstWrongAt: Date, lastWrongAt: Date) {
+        self.wrongFen = wrongFen
+        self.count = count
+        self.firstWrongAt = firstWrongAt
+        self.lastWrongAt = lastWrongAt
+    }
+}

--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -479,6 +479,16 @@ class Session: ObservableObject {
         dataChanged.toggle()
     }
 
+    // MARK: - 练习错误统计
+
+    /// 记录一次练习模式走错（基于 currentFenId）
+    /// - Parameter wrongBoardFen: 用户走出的局面 FEN（任意格式，会被标准化）
+    func recordPracticeMistakeAtCurrentFen(wrongBoardFen: String) {
+        let normalized = normalizeFen(wrongBoardFen)
+        databaseView.recordPracticeMistake(at: currentFenId, wrongFen: normalized)
+        dataChanged.toggle()
+    }
+
     var isCurrentBlackOrientation: Bool {
         sessionData.isBlackOrientation
     }

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -94,6 +94,7 @@ class ActionDefinitions {
         case showBookmarkListIOS
         case showMoreActionsIOS
         case showEditCommentIOS
+        case showPracticeMistakeStats  // 练习模式走错统计视图
     }
     
     // MARK: - 快捷键类型定义

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -55,6 +55,7 @@ class ViewModel: ObservableObject {
     @Published var showReviewListIOS = false
     @Published var showReviewModeIOS = false
     @Published var showingBoardTextView = false
+    @Published var showingPracticeMistakeStatsView = false
 
     // 复习模式状态
     @Published private(set) var reviewQueue: [(fenId: Int, srsData: SRSData)] = []
@@ -73,7 +74,8 @@ class ViewModel: ObservableObject {
                showingPGNImportSheet ||
                showMarkPathView ||
                showingReviewListView ||
-               showingBoardTextView
+               showingBoardTextView ||
+               showingPracticeMistakeStatsView
     }
 
     // Global alert state
@@ -346,6 +348,8 @@ class ViewModel: ObservableObject {
         actionDefinitions.registerAction(.showReviewListIOS, text: "复习库", shortcuts: [.sequence(",v")]) { self.showReviewListIOS = true }
         actionDefinitions.registerAction(.showRealGameListIOS, text: "实战", shortcuts: [.sequence(",g")]) { self.showRealGameListIOS = true }
         #endif
+
+        actionDefinitions.registerAction(.showPracticeMistakeStats, text: "练习错误统计", shortcuts: [.sequence(",ws")]) { self.showingPracticeMistakeStatsView = true }
       
         actionDefinitions.registerToggleAction(
           .setFilterNone,
@@ -655,6 +659,7 @@ class ViewModel: ObservableObject {
                     message: "棋谱结束"
                 )
             } else if !session.checkBoardFenInNextMoveList(newFen) {
+                session.recordPracticeMistakeAtCurrentFen(wrongBoardFen: newFen)
                 platformService.showWarningAlert(
                     title: "没有着法",
                     message: "没有着法，请检查棋谱是否正确。"

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -150,6 +150,9 @@ struct MacContentView: View {
         .sheet(isPresented: $viewModel.showingBoardTextView) {
             BoardTextView(viewModel: viewModel)
         }
+        .sheet(isPresented: $viewModel.showingPracticeMistakeStatsView) {
+            PracticeMistakeStatsView(viewModel: viewModel)
+        }
         .onChange(of: viewModel.isCommentEditing) { oldValue, newValue in
             // 当评论编辑状态从 true 变为 false 时，清除焦点
             if oldValue && !newValue {
@@ -353,6 +356,8 @@ struct MacMenuCommands: Commands {
             Divider()
             menuButton(.addToReview)
             menuButton(.showReviewList)
+            Divider()
+            menuButton(.showPracticeMistakeStats)
         }
     }
 

--- a/XiangqiNotebook/Views/PracticeMistakeStatsView.swift
+++ b/XiangqiNotebook/Views/PracticeMistakeStatsView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// 练习模式走错统计视图
+///
+/// 按 fenId 分组展示当前 DatabaseView 筛选范围内的错误：
+/// 顶层按"该局面累计走错总次数"从多到少排序；展开每个局面后可看到具体每个错招的次数和最近时间。
+struct PracticeMistakeStatsView: View {
+    @ObservedObject var viewModel: ViewModel
+    @State private var showingResetConfirmation = false
+
+    /// 触发重新计算的依赖：dataChanged 翻转时整个视图刷新
+    private var dataVersion: Bool { viewModel.session.dataChanged }
+
+    private struct Row: Identifiable {
+        let id: Int             // fenId
+        let fenId: Int
+        let totalCount: Int
+        let lastWrongAt: Date
+        let mistakes: [PracticeMistakeRecord]   // 该局面下各错招记录，按 count 降序
+        let fen: String          // 该局面的源 FEN（用于显示）
+    }
+
+    private var rows: [Row] {
+        let view = viewModel.session.databaseView
+        let mistakes = view.practiceMistakes
+        return mistakes.compactMap { (fenId, records) -> Row? in
+            guard !records.isEmpty else { return nil }
+            let total = records.reduce(0) { $0 + $1.count }
+            let last = records.map { $0.lastWrongAt }.max() ?? Date.distantPast
+            let sorted = records.sorted { $0.count > $1.count }
+            let fen = view.getFenObject(fenId)?.fen ?? "(unknown fen)"
+            return Row(id: fenId, fenId: fenId, totalCount: total,
+                       lastWrongAt: last, mistakes: sorted, fen: fen)
+        }
+        .sorted { lhs, rhs in
+            if lhs.totalCount != rhs.totalCount { return lhs.totalCount > rhs.totalCount }
+            return lhs.lastWrongAt > rhs.lastWrongAt
+        }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .short
+        return f
+    }()
+
+    var body: some View {
+        let _ = dataVersion
+        #if os(macOS)
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(minWidth: 540, minHeight: 400)
+        .alert("重置练习错误统计？", isPresented: $showingResetConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("重置", role: .destructive) { viewModel.session.databaseView.resetPracticeMistakes(); viewModel.session.dataChanged.toggle() }
+        } message: {
+            Text("此操作将清空所有练习错误记录，且无法撤销。")
+        }
+        #else
+        NavigationView {
+            content
+                .navigationTitle("练习错误统计")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("重置") { showingResetConfirmation = true }
+                            .disabled(rows.isEmpty)
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("关闭") { viewModel.showingPracticeMistakeStatsView = false }
+                    }
+                }
+        }
+        .alert("重置练习错误统计？", isPresented: $showingResetConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("重置", role: .destructive) { viewModel.session.databaseView.resetPracticeMistakes(); viewModel.session.dataChanged.toggle() }
+        } message: {
+            Text("此操作将清空所有练习错误记录，且无法撤销。")
+        }
+        #endif
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack {
+            Text("练习错误统计").font(.headline)
+            Spacer()
+            Text("当前筛选范围内 \(rows.count) 个局面").foregroundColor(.secondary)
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if rows.isEmpty {
+            VStack {
+                Spacer()
+                Text("当前筛选范围内尚无错误记录").foregroundColor(.secondary)
+                Spacer()
+            }
+        } else {
+            List {
+                ForEach(rows) { row in
+                    DisclosureGroup {
+                        ForEach(row.mistakes, id: \.wrongFen) { record in
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack {
+                                    Text("错招").foregroundColor(.secondary)
+                                    Text(record.wrongFen)
+                                        .font(.system(.caption, design: .monospaced))
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                    Spacer()
+                                    Text("× \(record.count)")
+                                        .font(.system(.body, design: .monospaced))
+                                }
+                                Text("最近：\(Self.dateFormatter.string(from: record.lastWrongAt))")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("局面 #\(row.fenId)")
+                                Text(row.fen)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                            Spacer()
+                            Text("\(row.totalCount)")
+                                .font(.system(.body, design: .monospaced))
+                                .frame(width: 60, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack {
+            Button("重置") { showingResetConfirmation = true }
+                .disabled(rows.isEmpty)
+            Spacer()
+            Button("关闭") { viewModel.showingPracticeMistakeStatsView = false }
+        }
+        .padding()
+    }
+}

--- a/XiangqiNotebook/Views/iOS/iPhoneContentView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneContentView.swift
@@ -79,6 +79,9 @@ struct iPhoneContentView: View {
         .sheet(isPresented: $viewModel.showReviewModeIOS) {
             iPhoneReviewModeView(viewModel: viewModel, isPresented: $viewModel.showReviewModeIOS)
         }
+        .sheet(isPresented: $viewModel.showingPracticeMistakeStatsView) {
+            PracticeMistakeStatsView(viewModel: viewModel)
+        }
         .alert(viewModel.globalAlertTitle, isPresented: $viewModel.showingGlobalAlert) {
             Button("确定") { }
         } message: {

--- a/XiangqiNotebook/Views/iOS/iPhoneMoreButtonsView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneMoreButtonsView.swift
@@ -56,6 +56,11 @@ struct iPhoneMoreOptionsView: View {
                         }
                         .frame(maxWidth: .infinity)
 
+                        HStack(spacing: 15) {
+                            iPhoneButton(viewModel: viewModel, actionKey: .showPracticeMistakeStats)
+                        }
+                        .frame(maxWidth: .infinity)
+
                         if viewModel.currentAppMode == .normal && viewModel.showRealGameList {
                             HStack(spacing: 15) {
                                 iPhoneButton(viewModel: viewModel, actionKey: .showRealGameListIOS)

--- a/XiangqiNotebookTests/PracticeMistakeStatsTests.swift
+++ b/XiangqiNotebookTests/PracticeMistakeStatsTests.swift
@@ -1,0 +1,156 @@
+import Testing
+import Foundation
+@testable import XiangqiNotebook
+
+struct PracticeMistakeStatsTests {
+
+    /// 创建一个空的测试数据库，并塞入若干 fenId
+    private func createTestDatabase(with fenIds: [Int]) -> Database {
+        let data = DatabaseData()
+        let db = Database(testDatabaseData: data)
+        for id in fenIds {
+            let fen = FenObject(fen: "fen\(id)", fenId: id)
+            db.databaseData.fenObjects2[id] = fen
+        }
+        return db
+    }
+
+    @Test
+    func recordIncrementsCountForSameWrongFen() {
+        let db = createTestDatabase(with: [1])
+        let view = DatabaseView.full(database: db)
+        let date1 = Date(timeIntervalSince1970: 100)
+        let date2 = Date(timeIntervalSince1970: 200)
+        view.recordPracticeMistake(at: 1, wrongFen: "wrongA", at: date1)
+        view.recordPracticeMistake(at: 1, wrongFen: "wrongA", at: date2)
+        let records = db.databaseData.practiceMistakes[1] ?? []
+        #expect(records.count == 1)
+        #expect(records.first?.wrongFen == "wrongA")
+        #expect(records.first?.count == 2)
+        #expect(records.first?.firstWrongAt == date1)
+        #expect(records.first?.lastWrongAt == date2)
+    }
+
+    @Test
+    func recordCreatesSeparateEntryForDifferentWrongFen() {
+        let db = createTestDatabase(with: [1])
+        let view = DatabaseView.full(database: db)
+        view.recordPracticeMistake(at: 1, wrongFen: "wrongA")
+        view.recordPracticeMistake(at: 1, wrongFen: "wrongB")
+        view.recordPracticeMistake(at: 1, wrongFen: "wrongA")
+        let records = db.databaseData.practiceMistakes[1] ?? []
+        #expect(records.count == 2)
+        let a = records.first { $0.wrongFen == "wrongA" }
+        let b = records.first { $0.wrongFen == "wrongB" }
+        #expect(a?.count == 2)
+        #expect(b?.count == 1)
+    }
+
+    @Test
+    func recordSeparatesByFenId() {
+        let db = createTestDatabase(with: [1, 2])
+        let view = DatabaseView.full(database: db)
+        view.recordPracticeMistake(at: 1, wrongFen: "x")
+        view.recordPracticeMistake(at: 2, wrongFen: "x")
+        view.recordPracticeMistake(at: 2, wrongFen: "x")
+        #expect(db.databaseData.practiceMistakes[1]?.first?.count == 1)
+        #expect(db.databaseData.practiceMistakes[2]?.first?.count == 2)
+    }
+
+    @Test
+    func resetClearsAllRecords() {
+        let db = createTestDatabase(with: [1])
+        let view = DatabaseView.full(database: db)
+        view.recordPracticeMistake(at: 1, wrongFen: "x")
+        view.recordPracticeMistake(at: 1, wrongFen: "y")
+        #expect(db.databaseData.practiceMistakes.isEmpty == false)
+        view.resetPracticeMistakes()
+        #expect(db.databaseData.practiceMistakes.isEmpty == true)
+    }
+
+    @Test
+    func recordMarksDatabaseDirty() {
+        let db = createTestDatabase(with: [1])
+        let view = DatabaseView.full(database: db)
+        // 创建后初始 isDirty 取决于实现，这里只验证 record 后必为 dirty
+        view.recordPracticeMistake(at: 1, wrongFen: "x")
+        // markDirty 是异步通过 DispatchQueue.main 设置 isDirty 的；
+        // 但 dataVersion 是同步在 main 异步块内自增。所以直接看底层数据是否写入。
+        #expect((db.databaseData.practiceMistakes[1]?.count ?? 0) == 1)
+    }
+
+    /// 视图过滤：DatabaseView.practiceMistakes 只返回筛选范围内 fenId 的记录
+    @Test
+    func filteringByDatabaseView() {
+        let db = createTestDatabase(with: [1, 2, 3])
+        // 让 fenId=1 在红方开局，2 在黑方开局，3 都不在
+        db.databaseData.fenObjects2[1]?.setInRedOpening(true)
+        db.databaseData.fenObjects2[2]?.setInBlackOpening(true)
+
+        let fullView = DatabaseView.full(database: db)
+        fullView.recordPracticeMistake(at: 1, wrongFen: "x")
+        fullView.recordPracticeMistake(at: 2, wrongFen: "x")
+        fullView.recordPracticeMistake(at: 3, wrongFen: "x")
+
+        let redView = DatabaseView.redOpening(database: db)
+        let redMistakes = redView.practiceMistakes
+        #expect(redMistakes.keys.contains(1) == true)
+        #expect(redMistakes.keys.contains(2) == false)
+        #expect(redMistakes.keys.contains(3) == false)
+
+        let blackView = DatabaseView.blackOpening(database: db)
+        let blackMistakes = blackView.practiceMistakes
+        #expect(blackMistakes.keys.contains(2) == true)
+        #expect(blackMistakes.keys.contains(1) == false)
+
+        // 完整视图应包含所有 3 个
+        #expect(fullView.practiceMistakes.keys.count == 3)
+    }
+
+    /// Codable 兼容性：旧数据（没有 practice_mistakes 字段）应能正常解码
+    @Test
+    func codableBackwardCompatibility() throws {
+        // 先编码一份空 DatabaseData 拿到完整 JSON，再剥掉 practice_mistakes 字段，
+        // 模拟旧版本数据库文件中不存在该字段的场景。
+        let original = DatabaseData()
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+        guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Issue.record("expected top-level JSON object")
+            return
+        }
+        json.removeValue(forKey: "practice_mistakes")
+        #expect(json.keys.contains("practice_mistakes") == false)
+        let strippedData = try JSONSerialization.data(withJSONObject: json)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(DatabaseData.self, from: strippedData)
+        #expect(decoded.practiceMistakes.isEmpty == true)
+    }
+
+    /// Codable 写入并重新读取后保持一致
+    @Test
+    func codableRoundtrip() throws {
+        let original = DatabaseData()
+        let date1 = Date(timeIntervalSince1970: 1000)
+        let date2 = Date(timeIntervalSince1970: 2000)
+        original.practiceMistakes = [
+            42: [
+                PracticeMistakeRecord(wrongFen: "wA", count: 3, firstWrongAt: date1, lastWrongAt: date2),
+                PracticeMistakeRecord(wrongFen: "wB", count: 1, firstWrongAt: date2, lastWrongAt: date2)
+            ]
+        ]
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(DatabaseData.self, from: data)
+        let records = decoded.practiceMistakes[42] ?? []
+        #expect(records.count == 2)
+        let wA = records.first { $0.wrongFen == "wA" }
+        let wB = records.first { $0.wrongFen == "wB" }
+        #expect(wA?.count == 3)
+        #expect(wA?.firstWrongAt == date1)
+        #expect(wA?.lastWrongAt == date2)
+        #expect(wB?.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `PracticeMistakeRecord` 结构体（wrongFen / count / firstWrongAt / lastWrongAt），存放在 `DatabaseData.practiceMistakes: [Int: [PracticeMistakeRecord]]` 中，沿用现有 `DatabaseStorage` 的 iCloud 协调流程持久化与同步
- `decodeIfPresent` 让旧数据库文件向后兼容
- `DatabaseView` 提供按筛选范围过滤的 `practiceMistakes` 访问、写入 (`recordPracticeMistake`)、清空 (`resetPracticeMistakes`)
- `Session.recordPracticeMistakeAtCurrentFen` 在 `ViewModel.handleBoardMove` 的练习模式失配分支被调用，把 (currentFenId, normalize(wrongFen)) 累加到统计；相同错招仅累加 count
- 新增 ActionKey `.showPracticeMistakeStats`，弹出 `PracticeMistakeStatsView`：按局面累计错误次数倒序，展开后看每一种错招的 count/最近时间，提供重置入口；Mac '练习'菜单 + iOS '更多'页面入口

Closes #19

## Test plan
- [x] 全量单元测试通过
- [x] 新增测试覆盖：累加、不同错招分别记录、不同 fenId 隔离、reset、DatabaseView 筛选、Codable 向后兼容（缺失 practice_mistakes 字段）+ roundtrip
- [ ] 手工验证：练习模式下走错招后再次走相同错招，统计中 count = 2
- [ ] 手工验证：走错不同错招产生多条记录
- [ ] 手工验证：切换筛选（如红方开局）后统计视图只显示该范围内的局面
- [ ] 手工验证：重启 App 后统计仍存在，iCloud 同步正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)