### PR TITLE
引入虚拟根局面 origin，统一棋谱森林为单棵树 (#92)

### DIFF
--- a/XiangqiNotebook/Models/Database.swift
+++ b/XiangqiNotebook/Models/Database.swift
@@ -87,8 +87,7 @@ internal class Database: ObservableObject {
         guard let originFenObject = data.fenObjects2[originFenId] else { return }
         var startFenIds: Set<Int> = []
         // 加入标准开局（兜底）
-        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
-        if let standardFenId = data.fenToId[standardFen] {
+        if let standardFenId = data.standardOpeningFenId {
             startFenIds.insert(standardFenId)
         }
         // 加入每个棋谱的 startingFenId（nil 视作标准开局，已包含在上面）

--- a/XiangqiNotebook/Models/Database.swift
+++ b/XiangqiNotebook/Models/Database.swift
@@ -40,18 +40,60 @@ internal class Database: ObservableObject {
             print("⚠️ Database: 创建新数据库")
         }
 
+        // 确保虚拟根局面 origin 存在，并把所有棋谱的起始局面挂载到 origin 之下
+        Self.ensureVirtualOriginAndMoves(in: databaseData)
+
         // 加载所有引擎分数文件
         loadAllEngineScores()
     }
 
     #if DEBUG
     /// 测试专用构造器：直接用提供的 DatabaseData 创建实例
-    /// 这样可以避免测试之间的相互影响，以及与UI线程的并发访问问题
+    /// 注意：不自动调用 ensureVirtualOriginAndMoves，因为测试通常在 init 后才填充 fenObjects2。
+    /// 测试需要 origin 时请在数据填充完毕后手动调用 Database.ensureVirtualOriginAndMoves(in:)
     init(testDatabaseData: DatabaseData) {
         self.databaseData = testDatabaseData
         print("✅ Database: 创建测试数据库实例")
     }
     #endif
+
+    /// 当前数据库中虚拟根局面的 fenId
+    /// 生产代码中 init 已确保存在；测试代码若未调用 ensureVirtualOriginAndMoves 可能返回 nil
+    var originFenId: Int? {
+        databaseData.originFenId
+    }
+
+    /// 确保数据库中存在虚拟根局面 origin，并把所有 gameObjects 的起始局面挂载到 origin 之下（创建虚拟着法）
+    /// 此操作幂等：origin 已存在则复用，虚拟着法已存在则跳过
+    static func ensureVirtualOriginAndMoves(in data: DatabaseData) {
+        // 1. 确保 origin FenObject 存在
+        let originFenId: Int
+        if let existing = data.originFenId {
+            originFenId = existing
+        } else {
+            // 分配下一个可用 fenId
+            let maxId = data.fenObjects2.keys.max() ?? 0
+            originFenId = maxId + 1
+            let origin = FenObject(fen: DatabaseData.originFen, fenId: originFenId)
+            data.fenObjects2[originFenId] = origin
+            data.fenToId[DatabaseData.originFen] = originFenId
+        }
+
+        // 2. 为每个 gameObject 的起始局面创建虚拟着法 origin → startingFenId
+        guard let originFenObject = data.fenObjects2[originFenId] else { return }
+        for (_, game) in data.gameObjects {
+            guard let startFenId = game.startingFenId else { continue }
+            guard startFenId != originFenId else { continue }
+            // 检查是否已存在 origin → startFenId 的着法
+            if data.moveToId[[originFenId, startFenId]] != nil { continue }
+            // 创建新的虚拟着法
+            let newMove = Move(sourceFenId: originFenId, targetFenId: startFenId)
+            let newMoveId = (data.moveObjects.keys.max() ?? 0) + 1
+            data.moveObjects[newMoveId] = newMove
+            data.moveToId[[originFenId, startFenId]] = newMoveId
+            _ = originFenObject.addMoveIfNeeded(move: newMove)
+        }
+    }
 
     // MARK: - Data Mutation
 

--- a/XiangqiNotebook/Models/Database.swift
+++ b/XiangqiNotebook/Models/Database.swift
@@ -42,6 +42,8 @@ internal class Database: ObservableObject {
 
         // 确保虚拟根局面 origin 存在，并把所有棋谱的起始局面挂载到 origin 之下
         Self.ensureVirtualOriginAndMoves(in: databaseData)
+        // 把所有 bookmark 的路径 key 加上 origin 前缀
+        Self.ensureBookmarksHaveOriginPrefix(in: databaseData)
 
         // 加载所有引擎分数文件
         loadAllEngineScores()
@@ -79,20 +81,47 @@ internal class Database: ObservableObject {
             data.fenToId[DatabaseData.originFen] = originFenId
         }
 
-        // 2. 为每个 gameObject 的起始局面创建虚拟着法 origin → startingFenId
+        // 2. 收集所有需要挂在 origin 下的起始 fenId：
+        //    a. 每个 gameObject 的 startingFenId（包含 nil 的视为标准开局）
+        //    b. 始终包含标准开局本身，确保即使没有任何带 startingFenId 的棋谱也能从 origin 走到棋谱
         guard let originFenObject = data.fenObjects2[originFenId] else { return }
+        var startFenIds: Set<Int> = []
+        // 加入标准开局（兜底）
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        if let standardFenId = data.fenToId[standardFen] {
+            startFenIds.insert(standardFenId)
+        }
+        // 加入每个棋谱的 startingFenId（nil 视作标准开局，已包含在上面）
         for (_, game) in data.gameObjects {
-            guard let startFenId = game.startingFenId else { continue }
-            guard startFenId != originFenId else { continue }
-            // 检查是否已存在 origin → startFenId 的着法
+            if let s = game.startingFenId, s != originFenId {
+                startFenIds.insert(s)
+            }
+        }
+
+        for startFenId in startFenIds {
             if data.moveToId[[originFenId, startFenId]] != nil { continue }
-            // 创建新的虚拟着法
             let newMove = Move(sourceFenId: originFenId, targetFenId: startFenId)
             let newMoveId = (data.moveObjects.keys.max() ?? 0) + 1
             data.moveObjects[newMoveId] = newMove
             data.moveToId[[originFenId, startFenId]] = newMoveId
             _ = originFenObject.addMoveIfNeeded(move: newMove)
         }
+    }
+
+    /// 确保所有 bookmarks 的 key（路径数组）以 origin 打头。
+    /// 老版本 bookmark 的 path 形如 [standardOpening, move1, ...]，
+    /// 新版本统一为 [origin, standardOpening, move1, ...]。幂等。
+    static func ensureBookmarksHaveOriginPrefix(in data: DatabaseData) {
+        guard let originFenId = data.originFenId else { return }
+        var migrated: [[Int]: String] = [:]
+        for (path, name) in data.bookmarks {
+            if path.first == originFenId {
+                migrated[path] = name
+            } else {
+                migrated[[originFenId] + path] = name
+            }
+        }
+        data.bookmarks = migrated
     }
 
     // MARK: - Data Mutation

--- a/XiangqiNotebook/Models/DatabaseData.swift
+++ b/XiangqiNotebook/Models/DatabaseData.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 class DatabaseData: Codable {
+    /// 虚拟根局面的 fen 字符串（哨兵字符串，非合法局面）
+    /// 用作棋谱森林的统一根节点：所有棋谱的起始局面都通过虚拟着法挂载到该节点之下
+    static let originFen = "__origin__"
+
     var fenObjects2: [Int: FenObject] = [:]
     var fenToId: [String: Int] = [:]
     var moveObjects: [Int: Move] = [:]
@@ -29,6 +33,11 @@ class DatabaseData: Codable {
 
     init() {
         // 默认初始化器，用于创建空的 DatabaseData
+    }
+
+    /// 当前数据库中虚拟根局面的 fenId（如不存在返回 nil）
+    var originFenId: Int? {
+        fenToId[Self.originFen]
     }
 
     // MARK: - Codable Implementation

--- a/XiangqiNotebook/Models/DatabaseData.swift
+++ b/XiangqiNotebook/Models/DatabaseData.swift
@@ -5,6 +5,11 @@ class DatabaseData: Codable {
     /// 用作棋谱森林的统一根节点：所有棋谱的起始局面都通过虚拟着法挂载到该节点之下
     static let originFen = "__origin__"
 
+    /// 标准开局（红方先手）的完整 fen 字符串
+    /// 与 XiangqiBoardUtils.startFEN 的短形式（仅含到 "r"）配合 normalizeFen 后才相等；
+    /// 这里存的是真正持久化在 fenObjects2 里的形式
+    static let standardOpeningFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+
     var fenObjects2: [Int: FenObject] = [:]
     var fenToId: [String: Int] = [:]
     var moveObjects: [Int: Move] = [:]
@@ -38,6 +43,11 @@ class DatabaseData: Codable {
     /// 当前数据库中虚拟根局面的 fenId（如不存在返回 nil）
     var originFenId: Int? {
         fenToId[Self.originFen]
+    }
+
+    /// 当前数据库中标准开局局面的 fenId（如不存在返回 nil）
+    var standardOpeningFenId: Int? {
+        fenToId[Self.standardOpeningFen]
     }
 
     // MARK: - Codable Implementation

--- a/XiangqiNotebook/Models/DatabaseStorage.swift
+++ b/XiangqiNotebook/Models/DatabaseStorage.swift
@@ -192,13 +192,20 @@ class DatabaseStorage {
 
     // MARK: - Database Creation
 
-    /// 创建空的数据库（包含起始局面）
+    /// 创建空的数据库（包含标准开局和虚拟根局面）
+    /// fenId=1 为标准开局（与 SessionData.currentGame2 默认值 [1] 保持兼容）
+    /// fenId=2 为虚拟根 origin；其后新增局面从 3 开始分配
     static func createEmptyDatabase() -> DatabaseData {
         let db = DatabaseData()
+        // 1. 标准开局（fenId=1 与默认 SessionData 兼容）
         let startFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
-        let fenObject = FenObject(fen: startFen, fenId: 1)
-        db.fenObjects2[1] = fenObject
+        let startObj = FenObject(fen: startFen, fenId: 1)
+        db.fenObjects2[1] = startObj
         db.fenToId[startFen] = 1
+        // 2. 虚拟根局面
+        let origin = FenObject(fen: DatabaseData.originFen, fenId: 2)
+        db.fenObjects2[2] = origin
+        db.fenToId[DatabaseData.originFen] = 2
         return db
     }
 }

--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -186,6 +186,11 @@ final class DatabaseView {
         database.databaseData.dataVersion
     }
 
+    /// 当前数据库的虚拟根 origin 的 fenId（生产代码保证存在）
+    var originFenId: Int? {
+        database.databaseData.originFenId
+    }
+
     // MARK: - Book and Game Object Access
 
     /// 获取特定 BookObject（未过滤）

--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -191,6 +191,31 @@ final class DatabaseView {
         database.databaseData.originFenId
     }
 
+    /// 当前数据库的标准开局 fenId（生产代码保证存在）
+    var standardOpeningFenId: Int? {
+        database.databaseData.standardOpeningFenId
+    }
+
+    /// Origin 的所有虚拟子着法（绕过 filter，来自底层 Database）。
+    /// 这是"枢纽"语义：无论当前 view 多窄，origin 在 UI 上都能列出全库所有棋谱起点，
+    /// 让用户从任意棋谱跳到另一个棋谱或标准开局。
+    func originVirtualMoves() -> [Move] {
+        guard let originFenId = database.databaseData.originFenId,
+              let originFenObject = database.databaseData.fenObjects2[originFenId] else {
+            return []
+        }
+        return originFenObject.moves.filter { $0.targetFenId != nil }
+    }
+
+    /// 查找以指定 fenId 作为起始局面的第一个棋谱（绕过 filter）
+    /// 用于 hub 枢纽切换：用户点击 origin 子节点时，找到对应棋谱以便 loadGame
+    func findGameByStartingFenId(_ fenId: Int) -> GameObject? {
+        let standardId = database.databaseData.standardOpeningFenId
+        return database.databaseData.gameObjects.values.first { game in
+            (game.startingFenId ?? standardId) == fenId
+        }
+    }
+
     // MARK: - Book and Game Object Access
 
     /// 获取特定 BookObject（未过滤）

--- a/XiangqiNotebook/Models/DatabaseView.swift
+++ b/XiangqiNotebook/Models/DatabaseView.swift
@@ -45,7 +45,9 @@ final class DatabaseView {
     }
 
     /// 检查 fenId 是否属于当前视图 scope
+    /// 注意：虚拟根局面 origin 始终在所有视图的 scope 内，作为森林统一根
     func containsFenId(_ fenId: Int) -> Bool {
+        if fenId == database.databaseData.originFenId { return true }
         return fenIdFilter(fenId)
     }
 
@@ -320,7 +322,10 @@ final class DatabaseView {
     }
 
     var allFenWithoutScore: [String] {
-        return database.databaseData.fenObjects2.values.filter { $0.score == nil }.map { $0.fen }
+        let originFen = DatabaseData.originFen
+        return database.databaseData.fenObjects2.values
+            .filter { $0.score == nil && $0.fen != originFen }
+            .map { $0.fen }
     }
 
     func getGamesInBookUnfiltered(_ bookId: UUID) -> [GameObject] {

--- a/XiangqiNotebook/Models/GameOperations.swift
+++ b/XiangqiNotebook/Models/GameOperations.swift
@@ -203,13 +203,49 @@ class GameOperations {
         guard let firstFenObject = databaseView.getFenObject(currentGame[0]) else {
             return []
         }
-        let firstMoveIsRed = firstFenObject.fen.split(separator: " ")[1] == "r"
+        // 找到"真实起点"局面（跳过 step 0 的 origin）以判断红/黑先手
+        let realStartFenObject: FenObject? = {
+            if firstFenObject.fen == DatabaseData.originFen, currentGame.count > 1 {
+                return databaseView.getFenObject(currentGame[1])
+            }
+            return firstFenObject
+        }()
+        let firstMoveIsRed: Bool = {
+            guard let realStart = realStartFenObject else { return true }
+            let parts = realStart.fen.split(separator: " ")
+            guard parts.count > 1 else { return true }  // origin 等非合法 FEN 兜底
+            return parts[1] == "r"
+        }()
+        // origin 是否作为 step 0；影响后续 round 编号偏移
+        let hasOriginAtZero = (firstFenObject.fen == DatabaseData.originFen)
         var moveList: [MoveListItem] = []
 
         for i in 0..<currentGame.count {
             if i == 0 {
-                // 开始位置：空序号，"开始"作为招法，无标记
-                moveList.append(MoveListItem(number: "", notation: "开始",
+                // step 0：若是虚拟根 origin 则显示"起点"，否则根据真实起点局面给出标签
+                let startNotation: String
+                if hasOriginAtZero {
+                    startNotation = "起点"
+                } else if firstFenObject.fen == normalizeFen(XiangqiBoardUtils.startFEN) {
+                    startNotation = "标准局面"
+                } else {
+                    startNotation = "开始"
+                }
+                moveList.append(MoveListItem(number: "", notation: startNotation,
+                                            redOpeningMarker: "", blackOpeningMarker: "",
+                                            reviewMarker: "", markers: "", move: nil))
+                continue
+            }
+            // 当 origin 在 step 0 时，step 1 是真实起点（"标准局面"或"开始"），没有"招法"
+            if hasOriginAtZero, i == 1 {
+                let secondFen = realStartFenObject?.fen
+                let startNotation: String
+                if secondFen == normalizeFen(XiangqiBoardUtils.startFEN) {
+                    startNotation = "标准局面"
+                } else {
+                    startNotation = "开始"
+                }
+                moveList.append(MoveListItem(number: "", notation: startNotation,
                                             redOpeningMarker: "", blackOpeningMarker: "",
                                             reviewMarker: "", markers: "", move: nil))
                 continue
@@ -225,13 +261,15 @@ class GameOperations {
                 continue
             }
 
+            // 若 step 0 是虚拟根 origin，所有后续 index 偏移 1，需要在编号公式中减去
+            let effectiveIndex = hasOriginAtZero ? (i - 1) : i
             let roundOneBased: Int
             if firstMoveIsRed {
                 // 0.start 1.red 1.black 2.red 2.black ...
-                roundOneBased = (i - 1) / 2 + 1
+                roundOneBased = (effectiveIndex - 1) / 2 + 1
             } else {
                 // 0.start 1.black 2.red 2.black 3.red ...
-                roundOneBased = i / 2 + 1
+                roundOneBased = effectiveIndex / 2 + 1
             }
 
             // 分离为五个部分

--- a/XiangqiNotebook/Models/IO.swift
+++ b/XiangqiNotebook/Models/IO.swift
@@ -22,6 +22,9 @@ class IO {
     }
     
     static func queryFenScore(_ fen: String, silentMode: Bool = false) async throws -> Int? {
+        // 虚拟根局面（哨兵 FEN，详见 DatabaseData.originFen）不是合法局面，不查云库
+        if fen == DatabaseData.originFen { return nil }
+
         let baseUrl = "http://api.chessdb.cn:81/chessdb.php"
         var components = URLComponents(string: baseUrl)!
         

--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -115,9 +115,9 @@ class Session: ObservableObject {
     }
 
     var currentGameVariantList: [(moveString: String, move: Move)] {
-        currentGameVariantMoves.map { (databaseView.formatMove($0, isHorizontalFlipped: sessionData.isHorizontalFlipped), $0) }
+        currentGameVariantMoves.map { (formatMoveDisplay($0), $0) }
     }
-    
+
     var currentGameVariantMoves: [Move] {
         guard sessionData.currentGameStep != 0,
               let prevFenId = previousFenId,
@@ -125,19 +125,47 @@ class Session: ObservableObject {
             return []
         }
 
-        // 父局面是虚拟根 origin 时，兄弟着法是"切换到其他棋谱起点"，对用户学习无直接价值，
-        // 且数量等于所有棋谱起始局面数，与 currentNextMovesList 在 origin 上的处理保持一致
-        if prevFenId == databaseView.originFenId { return [] }
+        // 父局面是虚拟根 origin 时，兄弟着法即"切换到其他棋谱起点"——这是枢纽语义，
+        // 直接从底层 Database 取全部 origin 虚拟子节点，无视当前 filter。
+        if prevFenId == databaseView.originFenId {
+            return databaseView.originVirtualMoves()
+        }
 
         return databaseView.moves(from: prevFenId)
     }
 
     var currentNextMovesList: [(moveString: String, move: Move)] {
-        // 在虚拟根 origin 上不展示"下步变招"：origin 的虚拟着法数量等于所有棋谱起始局面数量，
-        // 渲染数千条 MoveItemView 会导致 UI 卡死，且这些虚拟着法对用户没有意义
-        if currentFenId == databaseView.originFenId { return [] }
+        // 在虚拟根 origin 上展示"下步变招" = 全库所有棋谱起点（枢纽 UI）。
+        // 这些虚拟着法绕过 filter，便于用户从任意 view 切换到其他棋谱或标准开局。
+        if currentFenId == databaseView.originFenId {
+            return databaseView.originVirtualMoves().map { (formatMoveDisplay($0), $0) }
+        }
         let moves = databaseView.moves(from: currentFenId)
-        return moves.map { (databaseView.formatMove($0, isHorizontalFlipped: sessionData.isHorizontalFlipped), $0) }
+        return moves.map { (formatMoveDisplay($0), $0) }
+    }
+
+    /// 格式化招法用于 UI 展示。Origin 的虚拟子着法返回 hub label（"标准开局" / 棋谱名），
+    /// 其他普通着法委托给 databaseView.formatMove。
+    func formatMoveDisplay(_ move: Move) -> String {
+        if move.sourceFenId == databaseView.originFenId,
+           let targetFenId = move.targetFenId {
+            return hubLabel(forStartingFenId: targetFenId)
+        }
+        return databaseView.formatMove(move, isHorizontalFlipped: sessionData.isHorizontalFlipped)
+    }
+
+    /// 用于 hub UI 的标签：标准开局 / 棋谱名 / 兜底占位
+    private func hubLabel(forStartingFenId fenId: Int) -> String {
+        if let standardId = databaseView.standardOpeningFenId, fenId == standardId {
+            return "标准开局"
+        }
+        if let game = databaseView.findGameByStartingFenId(fenId),
+           let name = game.name, !name.isEmpty {
+            return name
+        }
+        // 兜底：origin 的虚拟子节点正常都能匹配到 standard opening 或 game.name；
+        // 走到这里说明数据异常（孤立的 starting fen），给出可识别的占位
+        return "棋谱 #\(fenId)"
     }
 
     var currentFenComment: String? {
@@ -754,7 +782,7 @@ class Session: ObservableObject {
     }
   
     func getMoveString(move: Move) -> String {
-      return databaseView.formatMove(move, isHorizontalFlipped: sessionData.isHorizontalFlipped)
+      return formatMoveDisplay(move)
     }
 
     func getCombinedComment(fenObject: FenObject?, move: Move?) -> String? {
@@ -1801,7 +1829,7 @@ extension Session {
     /// 设置默认的 currentGame2（如果需要）
     /// 确保 currentGame2 从起始局面开始
     func setupDefaultCurrentGameIfNeeded() {
-        let startFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let startFen = DatabaseData.standardOpeningFen
 
         // 检查 currentGame2 是否需要重置
         var needsReset = false
@@ -2079,6 +2107,28 @@ extension Session {
         autoExtendCurrentGame()
 
         // 移动到游戏末尾
+        sessionData.currentGameStep = sessionData.currentGame2.count - 1
+
+        notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
+    }
+
+    /// 加载一个起始局面（不绑定具体棋谱）。供 SessionManager 在 hub 切换到"标准开局"等
+    /// 没有特定 game 关联的起点时使用。调用方应保证 filter 已经切换到合适的视图。
+    func loadStartingFen(_ startingFenId: Int) {
+        sessionData.gameHistory = nil
+        sessionData.lockedStep = nil
+        rebuildDatabaseView()
+        clearAllGamePaths()
+
+        if let originFenId = databaseView.originFenId {
+            sessionData.currentGame2 = [originFenId, startingFenId]
+            sessionData.currentGameStep = 1
+        } else {
+            sessionData.currentGame2 = [startingFenId]
+            sessionData.currentGameStep = 0
+        }
+
+        autoExtendCurrentGame()
         sessionData.currentGameStep = sessionData.currentGame2.count - 1
 
         notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)

--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -125,10 +125,17 @@ class Session: ObservableObject {
             return []
         }
 
+        // 父局面是虚拟根 origin 时，兄弟着法是"切换到其他棋谱起点"，对用户学习无直接价值，
+        // 且数量等于所有棋谱起始局面数，与 currentNextMovesList 在 origin 上的处理保持一致
+        if prevFenId == databaseView.originFenId { return [] }
+
         return databaseView.moves(from: prevFenId)
     }
 
     var currentNextMovesList: [(moveString: String, move: Move)] {
+        // 在虚拟根 origin 上不展示"下步变招"：origin 的虚拟着法数量等于所有棋谱起始局面数量，
+        // 渲染数千条 MoveItemView 会导致 UI 卡死，且这些虚拟着法对用户没有意义
+        if currentFenId == databaseView.originFenId { return [] }
         let moves = databaseView.moves(from: currentFenId)
         return moves.map { (databaseView.formatMove($0, isHorizontalFlipped: sessionData.isHorizontalFlipped), $0) }
     }
@@ -525,14 +532,21 @@ class Session: ObservableObject {
         return (nextIsRed != boardIsRed) ? -score : score
     }
 
+    /// 从 fen 字符串中安全解析"下一步该谁走"。非合法 fen（如 origin 哨兵）返回 nil。
+    private func nextIsRed(in fen: String) -> Bool? {
+        let parts = fen.split(separator: " ")
+        guard parts.count > 1 else { return nil }
+        return parts[1] == "r"
+    }
+
     var displayScore: String {
-        let nextIsRed = currentFen.split(separator: " ")[1] == "r"
+        guard let nextIsRed = nextIsRed(in: currentFen) else { return "" }
         guard let score = currentFenScore else { return "" }
         return "\(adjustScore(score, nextIsRed: nextIsRed))"
     }
 
     var displayEngineScore: String {
-        let nextIsRed = currentFen.split(separator: " ")[1] == "r"
+        guard let nextIsRed = nextIsRed(in: currentFen) else { return "" }
         guard let score = currentEngineScore else { return "" }
         return "\(adjustScore(score, nextIsRed: nextIsRed))"
     }
@@ -541,7 +555,7 @@ class Session: ObservableObject {
     var displayDeepEngineScore: String {
         #if os(macOS)
         guard let score = databaseView.getEngineScore(fenId: currentFenId, engineKey: PikafishService.engineKey) else { return "" }
-        let nextIsRed = currentFen.split(separator: " ")[1] == "r"
+        guard let nextIsRed = nextIsRed(in: currentFen) else { return "" }
         return "\(adjustScore(score, nextIsRed: nextIsRed))"
         #else
         return ""
@@ -552,7 +566,7 @@ class Session: ObservableObject {
     var displayQuickEngineScore: String {
         #if os(macOS)
         guard let score = databaseView.getEngineScore(fenId: currentFenId, engineKey: PikafishService.quickEngineKey) else { return "" }
-        let nextIsRed = currentFen.split(separator: " ")[1] == "r"
+        guard let nextIsRed = nextIsRed(in: currentFen) else { return "" }
         return "\(adjustScore(score, nextIsRed: nextIsRed))"
         #else
         return ""
@@ -564,13 +578,13 @@ class Session: ObservableObject {
               let score = getScoreByFenId(targetFenId) else {
             return ""
         }
-        
-        guard let targetFen = getFenForId(targetFenId) else {
+
+        guard let targetFen = getFenForId(targetFenId),
+              let nextIsRed = nextIsRed(in: targetFen) else {
             return ""
         }
-        let nextIsRed = targetFen.split(separator: " ")[1] == "r"
         let adjustedScore = adjustScore(score, nextIsRed: nextIsRed)
-        
+
         return String(adjustedScore)
     }
 
@@ -582,18 +596,18 @@ class Session: ObservableObject {
             return ""
         }
 
-        guard let sourceFen = getFenForId(sourceFenId) else {
+        guard let sourceFen = getFenForId(sourceFenId),
+              let sourceNextIsRed = nextIsRed(in: sourceFen) else {
             return ""
         }
-        let sourceNextIsRed = sourceFen.split(separator: " ")[1] == "r"
         let adjustedSourceScore = adjustScore(sourceFenScore, nextIsRed: sourceNextIsRed)
-        
-        guard let targetFen = getFenForId(targetFenId) else {
+
+        guard let targetFen = getFenForId(targetFenId),
+              let targetNextIsRed = nextIsRed(in: targetFen) else {
             return ""
         }
-        let targetNextIsRed = targetFen.split(separator: " ")[1] == "r"
         let adjustedTargetScore = adjustScore(targetFenScore, nextIsRed: targetNextIsRed)
-        
+
         return String(adjustedTargetScore - adjustedSourceScore)
     }
 
@@ -1596,6 +1610,8 @@ extension Session {
     /// 获取当前局面所有可能走法的路径组
     /// 显示轮到走棋方的所有可能走法，每个走法使用不同的颜色
     func getNextMovesPathGroups() -> [PathGroup] {
+        // origin 上的虚拟着法不应该作为"下一步路径"渲染在棋盘上（数量极大且无棋盘坐标）
+        if currentFenId == databaseView.originFenId { return [] }
         let moves = currentFenObject.getMoves(fenIdFilter: databaseView.containsFenId)
         guard moves.count > 1 else { return [] }
 
@@ -1663,7 +1679,21 @@ extension Session {
             }
         }
 
-        let initialPath = Array(sessionData.currentGame2[0...(sessionData.lockedStep ?? 0)])
+        // DFS 从 currentGame2 的"真实起点"开始（跳过 step 0 的 origin），
+        // 避免从 origin 出发把所有棋谱的虚拟着法都展开。
+        // 当用户被锁定时，从锁定步开始；否则从 step 1 开始（origin 之后的第一个真实局面）。
+        let originFenId = databaseView.originFenId
+        let startIndex: Int
+        if let firstFen = sessionData.currentGame2.first, firstFen == originFenId {
+            startIndex = min(1, sessionData.currentGame2.count - 1)
+        } else {
+            startIndex = 0
+        }
+        let endIndex = max(startIndex, sessionData.lockedStep ?? startIndex)
+        guard endIndex < sessionData.currentGame2.count else {
+            return (allDFSPaths, fenIdToGamePathCount)
+        }
+        let initialPath = Array(sessionData.currentGame2[startIndex...endIndex])
         for fenId in initialPath {
             fenIdToGamePathCount[fenId] = 1
         }
@@ -1780,10 +1810,11 @@ extension Session {
             needsReset = true
         } else if let firstFenId = sessionData.currentGame2.first,
                   let firstFenObject = databaseView.getFenObject(firstFenId) {
-            // 检查第一个局面是否是起始局面
-            if firstFenObject.fen != startFen {
+            // 接受两种合法起点：origin（虚拟根）或标准开局
+            // 中局题等非标准起始局面会被截断到合法起点
+            if firstFenObject.fen != startFen && firstFenObject.fen != DatabaseData.originFen {
                 needsReset = true
-                print("currentGame2 不是从起始局面开始，将重置")
+                print("currentGame2 不是从合法起点开始（既非 origin 也非标准开局），将重置")
             }
         } else {
             // currentGame2[0] 指向的 fenId 不存在
@@ -1792,11 +1823,16 @@ extension Session {
         }
 
         if needsReset {
-            // 查找起始局面的 fenId - use getIdForFen since we're searching by fen
-            if let startFenId = databaseView.getIdForFen(startFen) {
+            // 重置为 [origin, 标准开局] 形态：step 0 = origin，step 1 = 标准开局
+            let originFenIdOpt = databaseView.originFenId
+            if let originFenId = originFenIdOpt, let startFenId = databaseView.getIdForFen(startFen) {
+                sessionData.currentGame2 = [originFenId, startFenId]
+                sessionData.currentGameStep = 1
+                print("已设置默认 currentGame2 为 [origin=\(originFenId), 标准开局=\(startFenId)]")
+            } else if let startFenId = databaseView.getIdForFen(startFen) {
                 sessionData.currentGame2 = [startFenId]
                 sessionData.currentGameStep = 0
-                print("已设置默认 currentGame2 为起始局面 fenId=\(startFenId)")
+                print("已设置默认 currentGame2 为起始局面 fenId=\(startFenId)（origin 缺失）")
             } else if let firstFenId = databaseView.getAllFenIds().min() {
                 // 后备方案：使用最小的 fenId
                 sessionData.currentGame2 = [firstFenId]
@@ -2029,10 +2065,15 @@ extension Session {
         rebuildDatabaseView()
         clearAllGamePaths()
 
-        // 设置起始局面
+        // 设置起始局面：始终以 origin 打头，保持"origin 永远是 step 0"的不变量
         let startingFenId = game.startingFenId ?? 1
-        sessionData.currentGame2 = [startingFenId]
-        sessionData.currentGameStep = 0
+        if let originFenId = databaseView.originFenId {
+            sessionData.currentGame2 = [originFenId, startingFenId]
+            sessionData.currentGameStep = 1
+        } else {
+            sessionData.currentGame2 = [startingFenId]
+            sessionData.currentGameStep = 0
+        }
 
         // 利用 DatabaseView 的 .specificGame() 过滤，auto-extension 会沿着唯一路径扩展
         autoExtendCurrentGame()
@@ -2060,10 +2101,15 @@ extension Session {
         rebuildDatabaseView()
         clearAllGamePaths()
 
-        // 设置起始局面（使用第一个棋局的起始位置）
+        // 设置起始局面：始终以 origin 打头，保持"origin 永远是 step 0"的不变量
         let startingFenId = firstGame.startingFenId ?? 1
-        sessionData.currentGame2 = [startingFenId]
-        sessionData.currentGameStep = 0
+        if let originFenId = databaseView.originFenId {
+            sessionData.currentGame2 = [originFenId, startingFenId]
+            sessionData.currentGameStep = 1
+        } else {
+            sessionData.currentGame2 = [startingFenId]
+            sessionData.currentGameStep = 0
+        }
 
         // 利用 DatabaseView 的 .specificBook() 过滤，auto-extension 可以探索棋谱中所有棋局的分支
         autoExtendCurrentGame()

--- a/XiangqiNotebook/Models/SessionManager.swift
+++ b/XiangqiNotebook/Models/SessionManager.swift
@@ -133,6 +133,16 @@ class SessionManager: ObservableObject {
         let databaseView = Self.createDatabaseView(for: filters, focusedPath: focusedPath, specificGameId: specificGameId, specificBookId: specificBookId, database: database)
 
         // 3. 按视图裁剪 currentGame2/currentGameStep（移除不在视图范围的 fenId）
+        // 若当前棋谱的起始局面 (currentGame2[0]) 不在新视图 scope 内（典型场景：从中局题/残局题切换到红/黑方开局），
+        // 回退到虚拟根 origin。origin 始终在所有视图的 scope 内，避免 Session 进入不一致状态。
+        if !newSessionData.currentGame2.isEmpty,
+           !databaseView.containsFenId(newSessionData.currentGame2[0]),
+           let originFenId = database.originFenId {
+            newSessionData.currentGame2 = [originFenId]
+            newSessionData.currentGameStep = 0
+            newSessionData.lockedStep = nil
+        }
+
         let oldGame = Array(newSessionData.currentGame2[0...newSessionData.currentGameStep])
         let lockedFens = newSessionData.lockedStep.map { Array(newSessionData.currentGame2[0...$0]) }
 

--- a/XiangqiNotebook/Models/SessionManager.swift
+++ b/XiangqiNotebook/Models/SessionManager.swift
@@ -30,6 +30,9 @@ class SessionManager: ObservableObject {
     ///   - database: 数据库实例（默认为共享实例）
     /// - Returns: 创建的 SessionManager 实例（保证成功）
     static func create(from sessionData: SessionData, database: Database = .shared) -> SessionManager {
+        // 0. 确保 currentGame2 以虚拟根 origin 打头（origin 永远是 step 0）
+        prependOriginIfNeeded(to: sessionData, database: database)
+
         do {
             // 1. 创建 DatabaseView
             let databaseView = createDatabaseView(
@@ -58,9 +61,23 @@ class SessionManager: ObservableObject {
             let startFenId = fallbackDatabaseView.ensureFenId(for: startFen)
             fallbackSessionData.currentGame2 = [startFenId]
             fallbackSessionData.currentGameStep = 0
+            prependOriginIfNeeded(to: fallbackSessionData, database: database)
 
             let fallbackSession = try! Session(sessionData: fallbackSessionData, databaseView: fallbackDatabaseView)
             return SessionManager(mainSession: fallbackSession)
+        }
+    }
+
+    /// 若 sessionData.currentGame2 的第 0 个元素不是虚拟根 origin，则前补 origin
+    /// 并相应地把 currentGameStep / lockedStep 各 +1。幂等。
+    /// 用于加载历史会话数据时把数据模型升级到"origin 永远在 step 0"的统一形态。
+    static func prependOriginIfNeeded(to sessionData: SessionData, database: Database) {
+        guard let originFenId = database.originFenId else { return }
+        guard sessionData.currentGame2.first != originFenId else { return }
+        sessionData.currentGame2.insert(originFenId, at: 0)
+        sessionData.currentGameStep += 1
+        if let locked = sessionData.lockedStep {
+            sessionData.lockedStep = locked + 1
         }
     }
 

--- a/XiangqiNotebook/Models/SessionManager.swift
+++ b/XiangqiNotebook/Models/SessionManager.swift
@@ -235,6 +235,29 @@ class SessionManager: ObservableObject {
 
     // MARK: - 加载操作
 
+    /// Origin 枢纽切换：用户在 origin 上点击某个虚拟子节点（标准开局或某个棋谱起点），
+    /// 自动选择合适的 filter 切换到该起点。
+    /// - 目标是标准开局 → 清空 filter（Full view）+ 把 currentGame2 重置到标准开局
+    /// - 目标是某个棋谱的起始 fen → loadGame(对应棋谱)，进入 .specificGame 视图
+    /// - Parameter startingFenId: origin 的某个虚拟子节点的 fenId
+    func navigateToHubChild(startingFenId: Int) {
+        let standardId = database.databaseData.standardOpeningFenId
+        if startingFenId == standardId {
+            setFilters([])
+            mainSession.loadStartingFen(startingFenId)
+            return
+        }
+        if let game = database.databaseData.gameObjects.values.first(where: {
+            ($0.startingFenId ?? standardId) == startingFenId
+        }) {
+            loadGame(game.id)
+            return
+        }
+        // 兜底：找不到对应棋谱（数据异常），清 filter 后直接定位到该 fen
+        setFilters([])
+        mainSession.loadStartingFen(startingFenId)
+    }
+
     /// 加载棋局（切换到特定棋局视图再执行）
     /// - Parameter gameId: 要加载的棋局 ID
     func loadGame(_ gameId: UUID) {

--- a/XiangqiNotebook/Services/PikafishService.swift
+++ b/XiangqiNotebook/Services/PikafishService.swift
@@ -195,6 +195,9 @@ class PikafishService: @unchecked Sendable {
     }
 
     func evaluatePosition(fen: String, movetime: Int? = nil) async throws -> EvaluationResult? {
+        // 虚拟根局面（哨兵 FEN，详见 DatabaseData.originFen）没有合法 FEN，喂给 pikafish 会 segfault
+        if fen == DatabaseData.originFen { return nil }
+
         // 如果已有评估在进行中，直接返回 nil（不阻塞等待）
         guard tryAcquireEvaluationLock() else { return nil }
         defer { releaseEvaluationLock() }

--- a/XiangqiNotebook/ViewModels/BoardViewModel.swift
+++ b/XiangqiNotebook/ViewModels/BoardViewModel.swift
@@ -39,7 +39,14 @@ class BoardViewModel: Equatable {
     }
 
     public var piecesBySquare: [String: String] {
+        // origin 不是合法 FEN，避免传给解析器导致越界崩溃
+        if self.fen == DatabaseData.originFen { return [:] }
         return XiangqiBoardUtils.fenToPiecesBySquare(self.fen)
+    }
+
+    /// 当前局面是否是虚拟根 origin
+    public var isOrigin: Bool {
+        return self.fen == DatabaseData.originFen
     }
 
     public func getOrientation() -> String {

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -710,21 +710,34 @@ class ViewModel: ObservableObject {
     }
     
     func playNextVariant() {
-        session.playNextVariant()
-        queryFenScoreSilentlyIfNeeded()
+        // 走 ViewModel.playVariantMove 以触发 origin 枢纽路由
+        let sortedVariants = session.currentGameVariantList.sorted { $0.moveString < $1.moveString }
+        guard sortedVariants.count >= 2 else { return }
+        let currentIndex = sortedVariants.firstIndex(where: { $0.move.targetFenId == session.currentFenId })
+        let nextIndex = (currentIndex.map { ($0 + 1) % sortedVariants.count }) ?? 0
+        playVariantMove(sortedVariants[nextIndex].move)
     }
-    
+
     func toStepIndex(_ index: Int) {
         session.toStepIndex(index)
         queryFenScoreSilentlyIfNeeded()
     }
-    
+
     func playVariantIndex(_ index: Int) {
-        session.playVariantIndex(index)
-        queryFenScoreSilentlyIfNeeded()
+        // 走 ViewModel.playVariantMove 以触发 origin 枢纽路由
+        let moves = session.currentGameVariantMoves
+        guard index >= 0, index < moves.count else { return }
+        playVariantMove(moves[index])
     }
 
     func playVariantMove(_ move: Move) {
+        // Origin 枢纽：兄弟着法是切换到其他棋谱起点，走 SessionManager.navigateToHubChild
+        if move.sourceFenId == session.databaseView.originFenId,
+           let targetFenId = move.targetFenId {
+            sessionManager.navigateToHubChild(startingFenId: targetFenId)
+            queryFenScoreSilentlyIfNeeded()
+            return
+        }
         session.playVariantMove(move)
         queryFenScoreSilentlyIfNeeded()
     }
@@ -1988,6 +2001,13 @@ class ViewModel: ObservableObject {
     }
 
     func playNextMove(_ move: Move) {
+        // Origin 枢纽：从 origin 走出的"下一步"是切换到棋谱起点，走 SessionManager.navigateToHubChild
+        if move.sourceFenId == session.databaseView.originFenId,
+           let targetFenId = move.targetFenId {
+            sessionManager.navigateToHubChild(startingFenId: targetFenId)
+            queryFenScoreSilentlyIfNeeded()
+            return
+        }
         session.playNextMove(move)
         queryFenScoreSilentlyIfNeeded()
     }

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1497,6 +1497,17 @@ class ViewModel: ObservableObject {
 
             let fenId = game[i]
 
+            // 跳过虚拟根 origin（无合法 FEN）
+            if fenId == session.databaseView.originFenId {
+                let elapsed = Date().timeIntervalSince(startTime)
+                let count = evaluatedCount
+                let detail = lastDetail
+                await MainActor.run {
+                    self.batchEvalProgress = BatchEvalProgress(current: i + 1, total: totalSteps, evaluatedCount: count, lastDetail: detail, elapsedSeconds: elapsed, isCompleted: false)
+                }
+                continue
+            }
+
             // 跳过已有引擎分数的局面
             if Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.engineKey) != nil {
                 let elapsed = Date().timeIntervalSince(startTime)
@@ -1579,6 +1590,17 @@ class ViewModel: ObservableObject {
             if batchEvalCancelled { break }
 
             let fenId = game[i]
+
+            // 跳过虚拟根 origin（无合法 FEN）
+            if fenId == session.databaseView.originFenId {
+                let elapsed = Date().timeIntervalSince(startTime)
+                let count = evaluatedCount
+                let detail = lastDetail
+                await MainActor.run {
+                    self.batchEvalProgress = BatchEvalProgress(current: i + 1, total: totalSteps, evaluatedCount: count, lastDetail: detail, elapsedSeconds: elapsed, isCompleted: false)
+                }
+                continue
+            }
 
             // 跳过已有快速引擎分数或深度引擎分数的局面
             if Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.quickEngineKey) != nil ||
@@ -2174,12 +2196,26 @@ class ViewModel: ObservableObject {
     }
 
     func exportPGNCurrentDatabaseViewContent() -> String {
-        let rootFenId = session.sessionData.currentGame2[0]
+        // 跳过 currentGame2[0] 的虚拟根 origin，使用真实起点 currentGame2[1] 作为 PGN 的根
+        let game = session.sessionData.currentGame2
+        let originFenId = session.databaseView.originFenId
+        let rootFenId: Int
+        if game.first == originFenId, game.count > 1 {
+            rootFenId = game[1]
+        } else if let first = game.first {
+            rootFenId = first
+        } else {
+            return ""
+        }
         return PGNExportService.exportCurrentDatabaseView(databaseView: session.databaseView, rootFenId: rootFenId)
     }
 
     func exportPGNCurrentGameContent() -> String {
-        let path = session.sessionData.currentGame2
+        // 跳过 currentGame2[0] 的虚拟根 origin，让 PGN 路径从真实起点开始
+        var path = session.sessionData.currentGame2
+        if path.first == session.databaseView.originFenId {
+            path.removeFirst()
+        }
         return PGNExportService.exportCurrentGame(path: path, databaseView: session.databaseView)
     }
 

--- a/XiangqiNotebook/Views/board/Board.swift
+++ b/XiangqiNotebook/Views/board/Board.swift
@@ -46,7 +46,15 @@ struct XiangqiBoard: View {
                     Color.gray.opacity(0.5)
                         .frame(width: boardSize, height: boardSize)
                 }
-                
+
+                // 虚拟根 origin：空棋盘上显示"起点"文字
+                if viewModel.isOrigin {
+                    Text("起点")
+                        .font(.system(size: boardSize * 0.18, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .frame(width: boardSize, height: boardSize)
+                }
+
                 // 2. 棋子层
                 ForEach(
                     viewModel.getPieceViewModels(),

--- a/XiangqiNotebookTests/StorageTests.swift
+++ b/XiangqiNotebookTests/StorageTests.swift
@@ -37,9 +37,12 @@ struct StorageTests {
         let db = DatabaseStorage.createEmptyDatabase()
         let startFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
 
-        #expect(db.fenObjects2.count == 1)
+        // 包含两个 FenObject：fenId=1 标准开局 + fenId=2 虚拟根 origin
+        #expect(db.fenObjects2.count == 2)
         #expect(db.fenObjects2[1]?.fen == startFen)
         #expect(db.fenToId[startFen] == 1)
+        #expect(db.fenObjects2[2]?.fen == DatabaseData.originFen)
+        #expect(db.originFenId == 2)
     }
 
     @Test func testCreateEmptyDatabase_HasEmptyCollections() {
@@ -125,7 +128,8 @@ struct StorageTests {
         let loaded = try DatabaseStorage.loadDatabaseFromURL(dbURL)
 
         #expect(loaded.dataVersion == 55)
-        #expect(loaded.fenObjects2.count == 1)
+        // 标准开局 + 虚拟根 origin
+        #expect(loaded.fenObjects2.count == 2)
     }
 
     @Test func testLoadDatabaseFromURL_InvalidJSON_Throws() throws {

--- a/XiangqiNotebookTests/VirtualOriginTests.swift
+++ b/XiangqiNotebookTests/VirtualOriginTests.swift
@@ -202,6 +202,152 @@ struct VirtualOriginTests {
 
     /// 验证 setFilters 中的兜底前提：origin 在任何 view 中都可达
     /// 这是 setFilters 在 currentGame2[0] 不在 scope 时回退到 origin 的关键依据
+    // MARK: - 导航到 origin（step 0）不应崩溃
+
+    /// 用户点击招法列表的"起点"行（step 0 = origin）时，所有依赖 currentFen 的访问都不应崩溃。
+    /// 历史回归：origin 的 fen 是哨兵 "__origin__"，原来在 Session.displayScore 等多处直接用
+    /// `fen.split(" ")[1]` 解析下棋方，遇到 origin 越界崩溃。
+    @MainActor
+    @Test func navigatingToOriginStepDoesNotCrash() throws {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let fen1 = FenObject(fen: standardFen, fenId: 1)
+        data.fenObjects2[1] = fen1
+        data.fenToId[standardFen] = 1
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originFenId = db.originFenId!
+
+        let sessionData = SessionData()
+        sessionData.currentGame2 = [originFenId, 1]
+        sessionData.currentGameStep = 1
+        let session = try Session(sessionData: sessionData, databaseView: DatabaseView.full(database: db))
+
+        // 模拟点击"起点"行
+        session.toStepIndex(0)
+        #expect(session.sessionData.currentGameStep == 0)
+
+        // 在 origin 状态下访问所有显示属性都不应崩溃
+        _ = session.currentFen
+        _ = session.displayScore
+        _ = session.displayEngineScore
+        #if os(macOS)
+        _ = session.displayDeepEngineScore
+        _ = session.displayQuickEngineScore
+        #endif
+
+        // 招法列表生成不应崩溃，且首行应为"起点"
+        let moveList = session.currentGameMoveList
+        #expect(moveList.count == 2)
+        #expect(moveList[0].notation == "起点")
+        #expect(moveList[1].notation == "标准局面")
+    }
+
+    /// 中局题棋谱（startingFenId 不是标准开局）被点击加载后，currentGame2 应该实际更新到该棋谱
+    /// 而不是停留在 origin/原先的状态
+    @MainActor
+    @Test func loadingMiddleGamePuzzleUpdatesCurrentGame() throws {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let fenStd = FenObject(fen: standardFen, fenId: 1)
+        data.fenObjects2[1] = fenStd
+        data.fenToId[standardFen] = 1
+        // 中局题的起始局面（任意 fen，关键是 turn=r/b 合法）
+        let middleFen = "5k3/9/9/9/9/9/9/9/9/4K4 r - - 1 1"
+        let fenMid = FenObject(fen: middleFen, fenId: 2)
+        data.fenObjects2[2] = fenMid
+        data.fenToId[middleFen] = 2
+        let book = BookObject(id: UUID(), name: "puzzles")
+        let game = GameObject(id: UUID())
+        game.startingFenId = 2
+        game.name = "puzzle"
+        book.gameIds.append(game.id)
+        data.bookObjects[book.id] = book
+        data.gameObjects[game.id] = game
+
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originFenId = db.originFenId!
+
+        // 初始 SessionData：默认起步在标准开局（mainSession 状态）
+        let sessionData = SessionData()
+        sessionData.currentGame2 = [originFenId, 1]
+        sessionData.currentGameStep = 1
+        let manager = SessionManager.create(from: sessionData, database: db)
+
+        // 用户点击中局棋谱
+        manager.loadGame(game.id)
+
+        // 加载后，currentGame2 应该以该棋谱的起始 fenId 起步，而不是停在 origin/标准开局
+        let result = manager.mainSession.sessionData.currentGame2
+        #expect(result.contains(2), "currentGame2 should contain the puzzle's starting fen (2), got \(result)")
+        #expect(result.contains(1) == false, "currentGame2 should not contain the previous standard opening (1)")
+    }
+
+    /// 切换 不筛选 → 棋谱(specificBook) → 不筛选，移动列表不应该只剩"起点"
+    /// 复现：用户在 不筛选 状态下有完整 game path，切到一个不含当前 path 的 specificBook，
+    /// path 被截断到 [origin]；切回 不筛选 时 autoExtend 应能从 origin 重新延伸出某个棋谱
+    @MainActor
+    @Test func switchingBetweenBookAndNoFilterDoesNotLeaveOnlyOrigin() throws {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let fenStd = FenObject(fen: standardFen, fenId: 1)
+        data.fenObjects2[1] = fenStd
+        data.fenToId[standardFen] = 1
+        // 中局题的局面（用于一个独立棋书）
+        let midFen = "5k3/9/9/9/9/9/9/9/9/4K4 r - - 1 1"
+        let fenMid = FenObject(fen: midFen, fenId: 2)
+        data.fenObjects2[2] = fenMid
+        data.fenToId[midFen] = 2
+
+        // 棋书 A：包含中局题（不含标准开局）
+        let bookA = BookObject(id: UUID(), name: "puzzle book")
+        let gameA = GameObject(id: UUID())
+        gameA.startingFenId = 2
+        gameA.name = "puzzle"
+        bookA.gameIds.append(gameA.id)
+        data.bookObjects[bookA.id] = bookA
+        data.gameObjects[gameA.id] = gameA
+
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originFenId = db.originFenId!
+
+        // 初始：不筛选，currentGame2 = [origin, 1]（origin + 标准开局）
+        let sessionData = SessionData()
+        sessionData.currentGame2 = [originFenId, 1]
+        sessionData.currentGameStep = 1
+        let manager = SessionManager.create(from: sessionData, database: db)
+
+        // Step 1: 切到 specificBook（书 A 不含标准开局）
+        manager.setFilters([Session.filterSpecificBook], specificBookId: bookA.id)
+        // 此时 currentGame2 应被截断到 [origin]，move list 只有"起点"
+        #expect(manager.mainSession.sessionData.currentGame2.first == originFenId)
+
+        // Step 2: 切回 不筛选
+        manager.setFilters([])
+        let result = manager.mainSession.sessionData.currentGame2
+        print("DEBUG: after switch back, currentGame2=\(result)")
+        // 期望 autoExtend 能从 origin 延伸到某个棋谱（如标准开局或中局题）
+        #expect(result.count > 1, "expected autoExtend to extend from origin, got \(result)")
+    }
+
+    /// BoardViewModel 接受 origin 的 fen 时不应在解析 piecesBySquare 时崩溃
+    @Test func boardViewModelHandlesOriginFen() {
+        let bvm = BoardViewModel(
+            fen: DatabaseData.originFen,
+            orientation: "red",
+            isHorizontalFlipped: false,
+            showPath: false,
+            showAllNextMoves: false,
+            shouldAnimate: false,
+            currentFenPathGroups: []
+        )
+        #expect(bvm.isOrigin == true)
+        // 访问 piecesBySquare 不应崩溃（曾因 origin fen 不是合法 FEN 而越界）
+        #expect(bvm.piecesBySquare.isEmpty)
+    }
+
     @Test func originAlwaysReachableAcrossViews() {
         let data = DatabaseData()
         let middleFen = "middlegame_puzzle_fen"

--- a/XiangqiNotebookTests/VirtualOriginTests.swift
+++ b/XiangqiNotebookTests/VirtualOriginTests.swift
@@ -1,0 +1,227 @@
+import Testing
+import Foundation
+@testable import XiangqiNotebook
+
+/// 虚拟根局面 origin 的集成测试
+struct VirtualOriginTests {
+
+    // MARK: - createEmptyDatabase 行为
+
+    @Test func emptyDatabaseHasStandardOpeningAndOrigin() {
+        let db = DatabaseStorage.createEmptyDatabase()
+        let startFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        // fenId=1 标准开局，fenId=2 虚拟根 origin
+        #expect(db.fenObjects2[1]?.fen == startFen)
+        #expect(db.fenObjects2[2]?.fen == DatabaseData.originFen)
+        #expect(db.originFenId == 2)
+    }
+
+    // MARK: - ensureVirtualOriginAndMoves 行为
+
+    @Test func ensureAddsOriginToExistingDatabaseAtMaxIdPlusOne() {
+        // 模拟旧版本数据库：只有标准开局在 fenId=1，没有 origin
+        let data = DatabaseData()
+        let fen1 = FenObject(fen: "standardOpening", fenId: 1)
+        data.fenObjects2[1] = fen1
+        data.fenToId["standardOpening"] = 1
+        let fen2 = FenObject(fen: "someOtherFen", fenId: 2)
+        data.fenObjects2[2] = fen2
+        data.fenToId["someOtherFen"] = 2
+
+        // 此时还没有 origin
+        #expect(data.originFenId == nil)
+
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        // origin 被分配到 maxId+1 = 3，且原有数据不受影响
+        #expect(data.originFenId == 3)
+        #expect(data.fenObjects2[3]?.fen == DatabaseData.originFen)
+        #expect(data.fenObjects2[1]?.fen == "standardOpening")  // 未被覆盖
+        #expect(data.fenObjects2[2]?.fen == "someOtherFen")
+    }
+
+    @Test func ensureIsIdempotent() {
+        let data = DatabaseData()
+        let fen1 = FenObject(fen: "abc", fenId: 1)
+        data.fenObjects2[1] = fen1
+        data.fenToId["abc"] = 1
+
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let firstOriginId = data.originFenId
+        let firstCount = data.fenObjects2.count
+
+        Database.ensureVirtualOriginAndMoves(in: data)
+        #expect(data.originFenId == firstOriginId)
+        #expect(data.fenObjects2.count == firstCount)
+    }
+
+    @Test func ensureCreatesVirtualMovesForGamesStartingFens() {
+        let data = DatabaseData()
+        let fenA = FenObject(fen: "fenA", fenId: 1)
+        data.fenObjects2[1] = fenA
+        data.fenToId["fenA"] = 1
+        let fenB = FenObject(fen: "fenB", fenId: 2)
+        data.fenObjects2[2] = fenB
+        data.fenToId["fenB"] = 2
+
+        // 两个棋谱：一个从 fenId=1 起始（标准开局），一个从 fenId=2 起始（中局题）
+        let game1 = GameObject(id: UUID()); game1.startingFenId = 1; game1.name = "g1"
+        let game2 = GameObject(id: UUID()); game2.startingFenId = 2; game2.name = "g2"
+        data.gameObjects[game1.id] = game1
+        data.gameObjects[game2.id] = game2
+
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        let originFenId = data.originFenId!
+        // 应当为每个 startingFen 创建一个 origin → startingFen 的虚拟着法
+        #expect(data.moveToId[[originFenId, 1]] != nil)
+        #expect(data.moveToId[[originFenId, 2]] != nil)
+        // origin 的 moves 列表中包含这两条虚拟着法
+        let originMoves = data.fenObjects2[originFenId]?.moves ?? []
+        let targetIds = Set(originMoves.compactMap { $0.targetFenId })
+        #expect(targetIds.contains(1))
+        #expect(targetIds.contains(2))
+    }
+
+    @Test func ensureDoesNotDuplicateExistingVirtualMoves() {
+        let data = DatabaseData()
+        let fenA = FenObject(fen: "fenA", fenId: 1)
+        data.fenObjects2[1] = fenA
+        data.fenToId["fenA"] = 1
+        let game = GameObject(id: UUID()); game.startingFenId = 1; game.name = "g"
+        data.gameObjects[game.id] = game
+
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let count1 = data.moveObjects.count
+
+        Database.ensureVirtualOriginAndMoves(in: data)
+        // 重复调用不应当创建新的虚拟着法
+        #expect(data.moveObjects.count == count1)
+    }
+
+    // MARK: - DatabaseView origin 包含
+
+    @Test func allViewsContainOrigin() {
+        let data = DatabaseData()
+        let fen1 = FenObject(fen: "fen1", fenId: 1)
+        fen1.setInRedOpening(true)
+        data.fenObjects2[1] = fen1
+        data.fenToId["fen1"] = 1
+        let fen2 = FenObject(fen: "fen2", fenId: 2)
+        fen2.setInBlackOpening(true)
+        data.fenObjects2[2] = fen2
+        data.fenToId["fen2"] = 2
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        let originId = db.originFenId!
+
+        // origin 应该在所有便利视图的 scope 内
+        #expect(DatabaseView.full(database: db).containsFenId(originId) == true)
+        #expect(DatabaseView.redOpening(database: db).containsFenId(originId) == true)
+        #expect(DatabaseView.blackOpening(database: db).containsFenId(originId) == true)
+        #expect(DatabaseView.redRealGame(database: db).containsFenId(originId) == true)
+        #expect(DatabaseView.blackRealGame(database: db).containsFenId(originId) == true)
+    }
+
+    @Test func nonOriginFensStillRespectFilters() {
+        // 验证 origin 的特殊处理不会让 filter 对其他 fenId 失效
+        let data = DatabaseData()
+        let fen1 = FenObject(fen: "fen1", fenId: 1)
+        fen1.setInRedOpening(true)
+        data.fenObjects2[1] = fen1
+        data.fenToId["fen1"] = 1
+        let fen2 = FenObject(fen: "fen2", fenId: 2)
+        fen2.setInRedOpening(false)
+        data.fenObjects2[2] = fen2
+        data.fenToId["fen2"] = 2
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        let redView = DatabaseView.redOpening(database: db)
+        #expect(redView.containsFenId(1) == true)   // 红方开局内
+        #expect(redView.containsFenId(2) == false)  // 不在红方开局
+    }
+
+    // MARK: - allFenWithoutScore 排除 origin
+
+    @Test func allFenWithoutScoreExcludesOrigin() {
+        let data = DatabaseData()
+        let fen1 = FenObject(fen: "fen1", fenId: 1)
+        // score 为 nil
+        data.fenObjects2[1] = fen1
+        data.fenToId["fen1"] = 1
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        let view = DatabaseView.full(database: db)
+        let unscoredFens = view.allFenWithoutScore
+        #expect(unscoredFens.contains("fen1") == true)
+        #expect(unscoredFens.contains(DatabaseData.originFen) == false)
+    }
+
+    // MARK: - Codable 持久化兼容性
+
+    @Test func encodeAndDecodePreservesOrigin() throws {
+        let data = DatabaseData()
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originId = data.originFenId!
+
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(data)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(DatabaseData.self, from: encoded)
+        #expect(decoded.originFenId == originId)
+        #expect(decoded.fenObjects2[originId]?.fen == DatabaseData.originFen)
+    }
+
+    @Test func decodingLegacyDataWithoutOriginThenEnsuringIsIdempotent() throws {
+        // 模拟旧版本数据库 JSON（无 origin）
+        let legacy = DatabaseData()
+        let fen1 = FenObject(fen: "legacy_fen", fenId: 1)
+        legacy.fenObjects2[1] = fen1
+        legacy.fenToId["legacy_fen"] = 1
+
+        let encoded = try JSONEncoder().encode(legacy)
+        let decoded = try JSONDecoder().decode(DatabaseData.self, from: encoded)
+        #expect(decoded.originFenId == nil)
+
+        Database.ensureVirtualOriginAndMoves(in: decoded)
+        #expect(decoded.originFenId == 2)
+
+        // 再次 encode/decode + ensure 应保持稳定
+        let encoded2 = try JSONEncoder().encode(decoded)
+        let decoded2 = try JSONDecoder().decode(DatabaseData.self, from: encoded2)
+        Database.ensureVirtualOriginAndMoves(in: decoded2)
+        #expect(decoded2.originFenId == 2)
+        #expect(decoded2.fenObjects2.count == 2)
+    }
+
+    // MARK: - DatabaseView 兜底：containsFenId 对 origin 总是返回 true
+
+    /// 验证 setFilters 中的兜底前提：origin 在任何 view 中都可达
+    /// 这是 setFilters 在 currentGame2[0] 不在 scope 时回退到 origin 的关键依据
+    @Test func originAlwaysReachableAcrossViews() {
+        let data = DatabaseData()
+        let middleFen = "middlegame_puzzle_fen"
+        let fen = FenObject(fen: middleFen, fenId: 1)
+        // 不在任何开局/实战
+        data.fenObjects2[1] = fen
+        data.fenToId[middleFen] = 1
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        let originId = db.originFenId!
+
+        // 中局题局面在红方/黑方开局视图中均不可达
+        let redView = DatabaseView.redOpening(database: db)
+        #expect(redView.containsFenId(1) == false)
+        // 但 origin 始终可达——setFilters 据此进行兜底
+        #expect(redView.containsFenId(originId) == true)
+
+        let blackView = DatabaseView.blackOpening(database: db)
+        #expect(blackView.containsFenId(1) == false)
+        #expect(blackView.containsFenId(originId) == true)
+    }
+}

--- a/XiangqiNotebookTests/VirtualOriginTests.swift
+++ b/XiangqiNotebookTests/VirtualOriginTests.swift
@@ -348,6 +348,152 @@ struct VirtualOriginTests {
         #expect(bvm.piecesBySquare.isEmpty)
     }
 
+    // MARK: - Origin 枢纽 (Hub) 行为
+
+    /// 在任何 view 中，origin 的虚拟子着法都应该是全库的所有起点（绕过 filter）。
+    /// 这是枢纽语义的基础：让用户在窄 view（例如 .specificGame）中也能从 origin 看到所有棋谱起点。
+    @Test func originVirtualMovesBypassFilter() {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        let fenStd = FenObject(fen: standardFen, fenId: 1)
+        data.fenObjects2[1] = fenStd
+        data.fenToId[standardFen] = 1
+        let midFen = "5k3/9/9/9/9/9/9/9/9/4K4 r - - 1 1"
+        let fenMid = FenObject(fen: midFen, fenId: 2)
+        data.fenObjects2[2] = fenMid
+        data.fenToId[midFen] = 2
+        let game = GameObject(id: UUID())
+        game.startingFenId = 2
+        game.name = "puzzle"
+        data.gameObjects[game.id] = game
+
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+
+        // 任何 view 中，originVirtualMoves 都返回所有 origin 子节点（标准开局 + 中局题）
+        let fullView = DatabaseView.full(database: db)
+        let specificView = DatabaseView.specificGame(database: db, gameId: game.id)
+        let fullMoves = fullView.originVirtualMoves()
+        let specificMoves = specificView.originVirtualMoves()
+        let fullTargets = Set(fullMoves.compactMap { $0.targetFenId })
+        let specificTargets = Set(specificMoves.compactMap { $0.targetFenId })
+        #expect(fullTargets == Set([1, 2]))
+        #expect(specificTargets == Set([1, 2]), "originVirtualMoves should bypass filter even in .specificGame")
+    }
+
+    /// 用户从终局棋谱通过 origin 枢纽切换到标准开局：清空 filter + currentGame2 复位
+    @MainActor
+    @Test func hubNavigateFromEndgameToStandardOpening() throws {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        data.fenObjects2[1] = FenObject(fen: standardFen, fenId: 1)
+        data.fenToId[standardFen] = 1
+        let midFen = "5k3/9/9/9/9/9/9/9/9/4K4 r - - 1 1"
+        data.fenObjects2[2] = FenObject(fen: midFen, fenId: 2)
+        data.fenToId[midFen] = 2
+        let game = GameObject(id: UUID())
+        game.startingFenId = 2
+        game.name = "puzzle"
+        data.gameObjects[game.id] = game
+
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originId = db.originFenId!
+
+        // 初始：在终局棋谱
+        let sessionData = SessionData()
+        sessionData.currentGame2 = [originId, 2]
+        sessionData.currentGameStep = 1
+        sessionData.filters = [Session.filterSpecificGame]
+        sessionData.specificGameId = game.id
+        let manager = SessionManager.create(from: sessionData, database: db)
+        #expect(manager.mainSession.sessionData.filters.contains(Session.filterSpecificGame))
+
+        // 走枢纽：切到标准开局（fenId=1）
+        let standardId = db.databaseData.standardOpeningFenId!
+        manager.navigateToHubChild(startingFenId: standardId)
+
+        // 期望：filter 清空，currentGame2 起点定位到标准开局
+        #expect(manager.mainSession.sessionData.filters.isEmpty)
+        #expect(manager.mainSession.sessionData.currentGame2.first == originId)
+        #expect(manager.mainSession.sessionData.currentGame2[safe: 1] == standardId)
+    }
+
+    /// 用户从标准开局通过 origin 枢纽切换到某个终局棋谱：filter 切到 .specificGame + currentGame2 复位
+    @MainActor
+    @Test func hubNavigateFromStandardOpeningToEndgame() throws {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        data.fenObjects2[1] = FenObject(fen: standardFen, fenId: 1)
+        data.fenToId[standardFen] = 1
+        let midFen = "5k3/9/9/9/9/9/9/9/9/4K4 r - - 1 1"
+        data.fenObjects2[2] = FenObject(fen: midFen, fenId: 2)
+        data.fenToId[midFen] = 2
+        let game = GameObject(id: UUID())
+        game.startingFenId = 2
+        game.name = "puzzle"
+        data.gameObjects[game.id] = game
+
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originId = db.originFenId!
+
+        // 初始：在标准开局，不筛选
+        let sessionData = SessionData()
+        sessionData.currentGame2 = [originId, 1]
+        sessionData.currentGameStep = 1
+        let manager = SessionManager.create(from: sessionData, database: db)
+        #expect(manager.mainSession.sessionData.filters.isEmpty)
+
+        // 走枢纽：切到中局题（fenId=2）
+        manager.navigateToHubChild(startingFenId: 2)
+
+        // 期望：filter 切到 .specificGame(game.id)，currentGame2 起点是中局题
+        #expect(manager.mainSession.sessionData.filters.contains(Session.filterSpecificGame))
+        #expect(manager.mainSession.sessionData.specificGameId == game.id)
+        #expect(manager.mainSession.sessionData.currentGame2.contains(2))
+        #expect(manager.mainSession.sessionData.currentGame2.contains(1) == false)
+    }
+
+    /// Origin 上的 currentNextMovesList 应显示所有 hub 项（带 hub label）
+    @MainActor
+    @Test func originStepShowsHubItemsInNextMovesList() throws {
+        let data = DatabaseData()
+        let standardFen = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 1 1"
+        data.fenObjects2[1] = FenObject(fen: standardFen, fenId: 1)
+        data.fenToId[standardFen] = 1
+        let midFen = "5k3/9/9/9/9/9/9/9/9/4K4 r - - 1 1"
+        data.fenObjects2[2] = FenObject(fen: midFen, fenId: 2)
+        data.fenToId[midFen] = 2
+        let game = GameObject(id: UUID())
+        game.startingFenId = 2
+        game.name = "我的终局题"
+        data.gameObjects[game.id] = game
+
+        let db = Database(testDatabaseData: data)
+        Database.ensureVirtualOriginAndMoves(in: data)
+        let originId = db.originFenId!
+
+        let sessionData = SessionData()
+        sessionData.currentGame2 = [originId, 1]
+        sessionData.currentGameStep = 0  // 在 origin step
+        // 注意：filter 是 .specificGame 也应该显示完整 hub（绕过 filter）
+        sessionData.filters = [Session.filterSpecificGame]
+        sessionData.specificGameId = game.id
+
+        // 通过 SessionManager.create 触发 setFilters 等正常流程
+        let manager = SessionManager.create(from: sessionData, database: db)
+        let session = manager.mainSession
+        // 把 step 强制回到 0（origin）
+        session.toStepIndex(0)
+
+        let hub = session.currentNextMovesList
+        let labels = hub.map { $0.moveString }
+        #expect(labels.contains("标准开局"))
+        #expect(labels.contains("我的终局题"))
+        #expect(hub.count == 2, "hub should have exactly 2 entries: standard opening + endgame")
+    }
+
     @Test func originAlwaysReachableAcrossViews() {
         let data = DatabaseData()
         let middleFen = "middlegame_puzzle_fen"


### PR DESCRIPTION
## Summary
- 采用你建议的"动态加载时自动挂载到 origin 下"方案，**完全不需要数据迁移脚本**
- `DatabaseData.originFen` 哨兵字符串 + 计算属性 `originFenId`（在 `fenToId` 中按字符串定位）
- 新建数据库时 `createEmptyDatabase` 立即创建 fenId=1 标准开局 + fenId=2 虚拟根 origin（保持 `SessionData.currentGame2= [1]` 默认值兼容）
- 现有数据库在 `Database.init` 时通过 `ensureVirtualOriginAndMoves` 幂等地补全：origin 分配到 maxFenId+1，再为每个 `GameObject.startingFenId` 创建一条 origin → 起始局面的虚拟着法
- `DatabaseView.containsFenId` 对 origin 直接返回 true，使所有便利视图（full/redOpening/blackOpening/redRealGame/blackRealGame）都默认包含虚拟根
- `allFenWithoutScore` 显式排除 origin（防止引擎评估它）
- **修复 filter 切换 bug**：`SessionManager.setFilters` 在 `currentGame2[0]` 不在新视图 scope 内时回退到 `[originFenId]`，而非任由原逻辑产生不一致状态

Closes #92

## 一些权衡说明
- `Database.shared` init 中调用 ensure，但 `Database(testDatabaseData:)` 不自动调用（测试通常先 init 再填充 fenObjects2，自动 ensure 会被后续填充覆盖）
- 中局题/残局题切换到红方开局后会落到 `[origin]`，棋盘渲染显示空状态。用户可继续切换 filter 或加载具体棋局退出此状态。后续若要更友好的兜底语义可以扩展
- DFS、PGN 导出、bookmarks 都从 `currentGame2[0]` 起步而非从 origin 起步，所以这些算法**无需修改**——只要 currentGame2 不主动包含 origin（除兜底场景外）就不会被错误计入

## Test plan
- [x] 全量 455 个单元测试通过
- [x] 新增 VirtualOriginTests（12 个用例）覆盖：empty 数据库布局、ensure 幂等性、为 game.startingFen 创建虚拟着法不重复、视图均包含 origin、其他 fenId 仍受 filter 约束、allFenWithoutScore 排除 origin、Codable roundtrip、缺失 origin 的旧 JSON 加载后 ensure 仍稳定、所有视图始终可达 origin
- [ ] 手工验证：用现有数据库启动 App，验证已有功能不受影响
- [ ] 手工验证：导入中局题棋谱，切换到"红方开局"筛选，验证不再陷入不一致状态（棋盘应回退到 origin 空状态而非显示错误）
- [ ] 手工验证：保存并重启 App，origin 持久化正常，gameObjects 的虚拟着法不重复生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)