### PR TITLE
招法评论区在无 currentMove 时禁用编辑

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1829,6 +1829,7 @@ class ViewModel: ObservableObject {
     var maxGameStepDisplay: Int { session.maxGameStepDisplay }
     var currentFenComment: String? { session.currentFenComment }
     var currentMoveComment: String? { session.currentMoveComment }
+    var hasCurrentMove: Bool { session.currentMove != nil }
     var currentMoveBadReason: String? { session.currentMoveBadReason }
     var currentCombinedComment: String? { session.currentCombinedComment }
     var bookmarkList: [(game: [Int], name: String)] { session.bookmarkList }

--- a/XiangqiNotebook/Views/CommentView.swift
+++ b/XiangqiNotebook/Views/CommentView.swift
@@ -35,6 +35,7 @@ struct CommentView: View {
                             viewModel.updateCurrentMoveComment(newValue)
                         }
                     ))
+                    .disabled(!viewModel.hasCurrentMove)
                     .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
                 } else {
                     Text(viewModel.currentMoveComment ?? "")


### PR DESCRIPTION
## Summary
- 开局第一步时 Session.currentMove == nil，此时招法评论区 TextEditor 仍可点击但 \`Session.updateCurrentMoveComment\` 会静默丢弃输入（\`guard let currentMove = currentMove else { return }\`）
- 在 ViewModel 新增 \`hasCurrentMove\` 便利属性，CommentView 中给招法评论区 TextEditor 加上 \`.disabled(!viewModel.hasCurrentMove)\`
- '不好的原因' TextEditor 通过 \`isCurrentMoveBad\`（已隐式 nil-guard）已经隐藏，无需改动
- 局面评论区基于 \`currentFenObject\`（始终存在）不受影响

注：这是预存 bug 不是 PR #95 引入的回归——但 #95 期间的焦点排查让这个症状暴露出来。

## Test plan
- [x] 全量单元测试通过
- [ ] 手工验证：开局第一步时，招法评论区显示为禁用（灰色），点击/输入无响应
- [ ] 手工验证：走第一招后，回退到 step 0，仍禁用
- [ ] 手工验证：前进到 step >= 1，招法评论区可正常编辑
- [ ] 手工验证：局面评论区在 step 0 仍可正常编辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)