### PR TITLE
棋盘界面显示当前局面的来源招法

### DIFF
--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -513,6 +513,10 @@ class Session: ObservableObject {
         sessionData.showAllNextMoves
     }
 
+    var showLastMove: Bool {
+        sessionData.showLastMove
+    }
+
     var showRealGameList: Bool {
         sessionData.showRealGameList
     }
@@ -1043,6 +1047,11 @@ extension Session {
 
     func toggleShowAllNextMoves() {
         sessionData.showAllNextMoves.toggle()
+        notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
+    }
+
+    func toggleShowLastMove() {
+        sessionData.showLastMove.toggle()
         notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
     }
 

--- a/XiangqiNotebook/Models/SessionData.swift
+++ b/XiangqiNotebook/Models/SessionData.swift
@@ -13,6 +13,7 @@ class SessionData: Codable {
     var currentMode: AppMode = .normal
     var showPath: Bool = true
     var showAllNextMoves: Bool = false
+    var showLastMove: Bool = true
     var showRealGameList: Bool = false
     var autoExtendGameWhenPlayingBoardFen: Bool = true
     var isCommentEditing: Bool = false
@@ -46,6 +47,7 @@ class SessionData: Codable {
         case currentMode = "current_mode"
         case showPath = "show_path"
         case showAllNextMoves = "show_all_next_moves"
+        case showLastMove = "show_last_move"
         case showRealGameList = "show_real_game_list"
         case autoExtendGameWhenPlayingBoardFen = "auto_extend_game_when_playing_board_fen"
         case isCommentEditing = "is_comment_editing"
@@ -72,6 +74,7 @@ class SessionData: Codable {
         canNavigateBeforeLockedStep = try container.decode(Bool.self, forKey: .canNavigateBeforeLockedStep)
         showPath = try container.decode(Bool.self, forKey: .showPath)
         showAllNextMoves = try container.decodeIfPresent(Bool.self, forKey: .showAllNextMoves) ?? false
+        showLastMove = try container.decodeIfPresent(Bool.self, forKey: .showLastMove) ?? true
         showRealGameList = try container.decodeIfPresent(Bool.self, forKey: .showRealGameList) ?? false
         autoExtendGameWhenPlayingBoardFen = try container.decode(Bool.self, forKey: .autoExtendGameWhenPlayingBoardFen)
         isCommentEditing = try container.decode(Bool.self, forKey: .isCommentEditing)
@@ -105,6 +108,7 @@ class SessionData: Codable {
         try container.encode(canNavigateBeforeLockedStep, forKey: .canNavigateBeforeLockedStep)
         try container.encode(showPath, forKey: .showPath)
         try container.encode(showAllNextMoves, forKey: .showAllNextMoves)
+        try container.encode(showLastMove, forKey: .showLastMove)
         try container.encode(showRealGameList, forKey: .showRealGameList)
         try container.encode(autoExtendGameWhenPlayingBoardFen, forKey: .autoExtendGameWhenPlayingBoardFen)
         try container.encode(isCommentEditing, forKey: .isCommentEditing)

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -82,6 +82,7 @@ class ActionDefinitions {
         case setReviewMode  // 切换到复习模式
         case toggleShowPath  // 新增：显示路径按钮
         case toggleShowAllNextMoves  // 新增：显示所有下一步按钮
+        case toggleShowLastMove  // 新增：显示来源招法按钮
         case toggleShowRealGameList  // 新增：显示实战列表按钮
         case toggleBookmark  // 新增：显示路径按钮
         case toggleIsCommentEditing

--- a/XiangqiNotebook/ViewModels/BoardViewModel.swift
+++ b/XiangqiNotebook/ViewModels/BoardViewModel.swift
@@ -10,6 +10,7 @@ class BoardViewModel: Equatable {
     private var pieceViewModels: [PieceViewModel] = createPieceViewModels()
     private var currentFenPathGroups: [PathGroup]
     private var nextMovesPathGroups: [PathGroup]
+    private var lastMoveSquares: (from: String, to: String)?
 
     static func == (lhs: BoardViewModel, rhs: BoardViewModel) -> Bool {
         return lhs.pieceViewModels == rhs.pieceViewModels
@@ -26,7 +27,7 @@ class BoardViewModel: Equatable {
         nextMovesPathGroups: []
     )
 
-    init(fen: String, orientation: String, isHorizontalFlipped: Bool, showPath: Bool, showAllNextMoves: Bool, shouldAnimate: Bool, currentFenPathGroups: [PathGroup], nextMovesPathGroups: [PathGroup] = []) {
+    init(fen: String, orientation: String, isHorizontalFlipped: Bool, showPath: Bool, showAllNextMoves: Bool, shouldAnimate: Bool, currentFenPathGroups: [PathGroup], nextMovesPathGroups: [PathGroup] = [], lastMoveSquares: (from: String, to: String)? = nil) {
         self.fen = fen
         self.orientation = orientation
         self.isHorizontalFlipped = isHorizontalFlipped
@@ -35,6 +36,7 @@ class BoardViewModel: Equatable {
         self.shouldAnimate = shouldAnimate
         self.currentFenPathGroups = currentFenPathGroups
         self.nextMovesPathGroups = nextMovesPathGroups
+        self.lastMoveSquares = lastMoveSquares
         updatePieceViews(fen: fen, force: true)
     }
 
@@ -68,6 +70,10 @@ class BoardViewModel: Equatable {
 
     public func getNextMovesPathGroups() -> [PathGroup] {
         return self.nextMovesPathGroups
+    }
+
+    public func getLastMoveSquares() -> (from: String, to: String)? {
+        return self.lastMoveSquares
     }
     
     public func getCurrentTurn() -> String {
@@ -146,6 +152,10 @@ class BoardViewModel: Equatable {
 
     public func updateShowAllNextMoves(showAllNextMoves: Bool) {
         self.showAllNextMoves = showAllNextMoves
+    }
+
+    public func updateLastMoveSquares(_ squares: (from: String, to: String)?) {
+        self.lastMoveSquares = squares
     }
 
     public func updateShouldAnimate(_ shouldAnimate: Bool) {

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -253,6 +253,15 @@ class ViewModel: ObservableObject {
             }
     }
 
+    private var currentMoveSquares: (from: String, to: String)? {
+        guard let move = session.currentMove,
+              let pieceMove = session.databaseView.parsePieceMove(move, isHorizontalFlipped: false)
+        else { return nil }
+        let fromSquare = MoveRules.coordinateToSquare(col: pieceMove.fromColumn, row: 9 - pieceMove.fromRow)
+        let toSquare = MoveRules.coordinateToSquare(col: pieceMove.toColumn, row: 9 - pieceMove.toRow)
+        return (from: fromSquare, to: toSquare)
+    }
+
     /// 更新棋盘视图（数据变化时调用）
     private func updateBoardView() {
         boardViewModel.updatePieceViews(fen: session.currentFen)
@@ -262,7 +271,7 @@ class ViewModel: ObservableObject {
         boardViewModel.updateNextMovesPathGroups(nextMovesPathGroups: session.getNextMovesPathGroups())
         boardViewModel.updateShowPath(showPath: showPath)
         boardViewModel.updateShowAllNextMoves(showAllNextMoves: showAllNextMoves)
-
+        boardViewModel.updateLastMoveSquares(showLastMove ? currentMoveSquares : nil)
 
         // 通知 ViewModel 的观察者（View）
         objectWillChange.send()
@@ -597,6 +606,19 @@ class ViewModel: ObservableObject {
           isOn: { self.showAllNextMoves },
           action: { newValue in
             self.toggleShowAllNextMoves()
+          }
+        )
+
+        // 显示来源招法 - 所有模式可用
+        actionDefinitions.registerToggleAction(
+          .toggleShowLastMove,
+          text: "显示来源招法",
+          shortcuts: [.sequence(",l")],
+          supportedModes: ActionDefinitions.allModes,
+          isEnabled: { true },
+          isOn: { self.showLastMove },
+          action: { newValue in
+            self.toggleShowLastMove()
           }
         )
 
@@ -2079,6 +2101,7 @@ class ViewModel: ObservableObject {
     var currentAppMode: AppMode { session.currentAppMode }
     var showPath: Bool { session.showPath }
     var showAllNextMoves: Bool { session.showAllNextMoves }
+    var showLastMove: Bool { session.showLastMove }
     var showRealGameList: Bool { session.showRealGameList }
     var isCommentEditing: Bool { session.isCommentEditing }
     var currentDataVersion: Int { session.currentDataVersion }
@@ -2286,6 +2309,10 @@ class ViewModel: ObservableObject {
 
     func toggleShowAllNextMoves() {
         session.toggleShowAllNextMoves()
+    }
+
+    func toggleShowLastMove() {
+        session.toggleShowLastMove()
     }
 
     func toggleShowRealGameList() {

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -288,6 +288,7 @@ struct MacMenuCommands: Commands {
             Divider()
             menuToggle(.toggleShowPath)
             menuToggle(.toggleShowAllNextMoves)
+            menuToggle(.toggleShowLastMove)
             Divider()
             menuToggle(.toggleIsCommentEditing)
             menuToggle(.toggleAllowAddingNewMoves)

--- a/XiangqiNotebook/Views/TogglesView.swift
+++ b/XiangqiNotebook/Views/TogglesView.swift
@@ -50,6 +50,7 @@ struct BoardOperationTogglesView: View {
             MyToggle(viewModel: viewModel, actionKey: .toggleCanNavigateBeforeLockedStep)
             MyToggle(viewModel: viewModel, actionKey: .toggleShowPath)
             MyToggle(viewModel: viewModel, actionKey: .toggleShowAllNextMoves)
+            MyToggle(viewModel: viewModel, actionKey: .toggleShowLastMove)
             MyToggle(viewModel: viewModel, actionKey: .toggleShowRealGameList)
             MyToggle(viewModel: viewModel, actionKey: .togglePracticeMode)
             MyToggle(viewModel: viewModel, actionKey: .toggleIsCommentEditing)

--- a/XiangqiNotebook/Views/board/Board.swift
+++ b/XiangqiNotebook/Views/board/Board.swift
@@ -47,6 +47,39 @@ struct XiangqiBoard: View {
                         .frame(width: boardSize, height: boardSize)
                 }
                 
+                // 1.5 来源招法高亮层（棋子下方）
+                if let lastMove = viewModel.getLastMoveSquares() {
+                    let fromPosition = BoardViewModel.calculateDisplayPosition(
+                        square: lastMove.from,
+                        squareSizeWidth: squareSizeWidth,
+                        squareSizeHeight: squareSizeHeight,
+                        pieceDiffX: pieceDiffX,
+                        pieceDiffY: pieceDiffY,
+                        orientation: viewModel.getOrientation(),
+                        isHorizontalFlipped: viewModel.getIsHorizontalFlipped()
+                    )
+                    HighlightSquareView(
+                        squareSize: squareSize,
+                        position: fromPosition,
+                        color: .orange
+                    )
+
+                    let toPosition = BoardViewModel.calculateDisplayPosition(
+                        square: lastMove.to,
+                        squareSizeWidth: squareSizeWidth,
+                        squareSizeHeight: squareSizeHeight,
+                        pieceDiffX: pieceDiffX,
+                        pieceDiffY: pieceDiffY,
+                        orientation: viewModel.getOrientation(),
+                        isHorizontalFlipped: viewModel.getIsHorizontalFlipped()
+                    )
+                    HighlightSquareView(
+                        squareSize: squareSize,
+                        position: toPosition,
+                        color: .orange
+                    )
+                }
+
                 // 2. 棋子层
                 ForEach(
                     viewModel.getPieceViewModels(),


### PR DESCRIPTION
## Summary
- 在棋盘背景和棋子层之间添加橙色高亮，标记上一步棋的起点和终点
- 新增 showLastMove 开关（默认打开），可在 iOS/macOS 界面上查看和切换
- 快捷键：,l（逗号 + l）
- 复用现有 HighlightSquareView 组件，高亮放在棋子层下方，视觉上比较含蓄

## Test plan
- [ ] 运行全部单元测试验证无回归
- [ ] 在 macOS 上运行 app，验证初始局面无高亮
- [ ] 前进一步后，棋盘上显示橙色高亮（起点和终点）
- [ ] 后退到初始局面，高亮消失
- [ ] 切换棋盘方向（红/黑），高亮位置正确跟随
- [ ] 水平翻转棋盘，高亮位置正确跟随
- [ ] 打开/关闭"显示来源招法"开关，高亮显示/隐藏
- [ ] 验证高亮不干扰棋子选择和走子操作

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)