### PR TITLE
支持远程操控和截图能力，实现 AI Agent 自动化 UI 测试 (#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,41 @@ xcodebuild test -project XiangqiNotebook.xcodeproj -scheme XiangqiNotebook -dest
 xcodebuild test -project XiangqiNotebook.xcodeproj -scheme XiangqiNotebook -destination 'platform=macOS' -only-testing:XiangqiNotebookTests/TestClassName/testMethodName 2>&1 | grep -E "TEST (SUCCEEDED|FAILED)|error:|fatal:"
 ```
 
+## 远程操控与 UI 验证（仅 DEBUG 构建）
+
+DEBUG 构建下，app 启动后会自动在 `localhost:9214` 启动远程操控 HTTP 服务器（`RemoteControlServer`），提供截图、状态查询和操作执行接口。
+
+### API 接口
+
+```bash
+# 截图当前窗口（返回 PNG）
+curl http://localhost:9214/screenshot -o /tmp/screenshot.png
+
+# 获取当前应用状态（返回 JSON）
+curl http://localhost:9214/state
+
+# 执行操作（action 名称对应 ActionDefinitions.ActionKey）
+curl -X POST http://localhost:9214/action -d '{"action":"stepForward"}'
+
+# Toggle 操作可指定目标值
+curl -X POST http://localhost:9214/action -d '{"action":"toggleShowPath","value":true}'
+
+# 列出所有可用操作
+curl http://localhost:9214/actions
+```
+
+### UI 变更验证流程
+
+修改 View 层或 ViewModel 层代码后，除了运行单元测试，还应通过远程操控接口进行视觉验证：
+
+1. 构建并运行 app（DEBUG 配置）
+2. 用 `curl http://localhost:9214/screenshot -o $TMPDIR/screenshot.png` 获取截图
+3. 读取截图文件进行视觉检查（Claude 支持多模态图片理解）
+4. 用 `curl http://localhost:9214/state` 验证状态数据是否符合预期
+5. 需要时用 `/action` 接口触发操作后再截图对比
+
+这是对单元测试的补充，不替代测试。
+
 ## Git 提交禁止事项
 
 - **禁止提交 `DEVELOPMENT_TEAM`**: 绝不能将 `DEVELOPMENT_TEAM` 设置提交到 git。如果 `project.pbxproj` 中出现 `DEVELOPMENT_TEAM` 的改动，必须在提交前 revert 该行。

--- a/XiangqiNotebook/Models/RemoteControlServer.swift
+++ b/XiangqiNotebook/Models/RemoteControlServer.swift
@@ -1,0 +1,284 @@
+#if DEBUG
+#if os(macOS)
+import Foundation
+import Network
+import AppKit
+
+class RemoteControlServer {
+    private var listener: NWListener?
+    private let port: UInt16 = 9214
+    private let queue = DispatchQueue(label: "RemoteControlServer")
+
+    weak var viewModel: ViewModel?
+
+    func start() throws {
+        let params = NWParameters.tcp
+        params.acceptLocalOnly = true
+        let nwPort = NWEndpoint.Port(rawValue: port)!
+        listener = try NWListener(using: params, on: nwPort)
+
+        listener?.newConnectionHandler = { [weak self] connection in
+            self?.handleConnection(connection)
+        }
+
+        listener?.stateUpdateHandler = { state in
+            if case .failed(let error) = state {
+                print("RemoteControlServer listener failed: \(error)")
+            }
+        }
+
+        listener?.start(queue: queue)
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    private func handleConnection(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        receiveHTTPRequest(connection: connection, accumulated: Data())
+    }
+
+    private func receiveHTTPRequest(connection: NWConnection, accumulated: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] content, _, isComplete, error in
+            guard let self else { return }
+
+            var data = accumulated
+            if let content { data.append(content) }
+
+            if let error {
+                print("RemoteControlServer receive error: \(error)")
+                connection.cancel()
+                return
+            }
+
+            if self.hasCompleteHTTPRequest(data) || isComplete {
+                self.processHTTPRequest(data: data, connection: connection)
+            } else {
+                self.receiveHTTPRequest(connection: connection, accumulated: data)
+            }
+        }
+    }
+
+    private func hasCompleteHTTPRequest(_ data: Data) -> Bool {
+        guard let str = String(data: data, encoding: .utf8) else { return false }
+        guard let headerEnd = str.range(of: "\r\n\r\n") else { return false }
+
+        let headerPart = str[str.startIndex..<headerEnd.lowerBound]
+        if let clRange = headerPart.range(of: "Content-Length: ", options: .caseInsensitive) {
+            let afterCL = headerPart[clRange.upperBound...]
+            if let lineEnd = afterCL.firstIndex(of: "\r") ?? afterCL.firstIndex(of: "\n"),
+               let contentLength = Int(afterCL[afterCL.startIndex..<lineEnd]) {
+                let bodyStart = str[headerEnd.upperBound...]
+                return bodyStart.utf8.count >= contentLength
+            }
+        }
+
+        return true
+    }
+
+    // MARK: - Routing
+
+    private func processHTTPRequest(data: Data, connection: NWConnection) {
+        guard let str = String(data: data, encoding: .utf8) else {
+            sendJSONResponse(connection: connection, status: "400 Bad Request",
+                             body: #"{"error":"Invalid request encoding"}"#)
+            return
+        }
+
+        let firstLine = str.prefix(while: { $0 != "\r" && $0 != "\n" })
+        let parts = firstLine.split(separator: " ")
+        guard parts.count >= 2 else {
+            sendJSONResponse(connection: connection, status: "400 Bad Request",
+                             body: #"{"error":"Malformed request line"}"#)
+            return
+        }
+
+        let method = String(parts[0])
+        let path = String(parts[1])
+
+        var body = ""
+        if let headerEnd = str.range(of: "\r\n\r\n") {
+            body = String(str[headerEnd.upperBound...])
+        }
+
+        switch (method, path) {
+        case ("GET", "/screenshot"):
+            handleScreenshot(connection: connection)
+        case ("POST", "/action"):
+            handleAction(body: body, connection: connection)
+        case ("GET", "/state"):
+            handleState(connection: connection)
+        case ("GET", "/actions"):
+            handleListActions(connection: connection)
+        default:
+            sendJSONResponse(connection: connection, status: "404 Not Found",
+                             body: #"{"error":"Unknown endpoint"}"#)
+        }
+    }
+
+    // MARK: - Screenshot
+
+    private func handleScreenshot(connection: NWConnection) {
+        DispatchQueue.main.sync {
+            guard let window = NSApplication.shared.windows.first(where: { $0.isKeyWindow })
+                    ?? NSApplication.shared.windows.first,
+                  let view = window.contentView else {
+                sendJSONResponse(connection: connection, status: "503 Service Unavailable",
+                                 body: #"{"error":"No window available"}"#)
+                return
+            }
+
+            guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+                sendJSONResponse(connection: connection, status: "500 Internal Server Error",
+                                 body: #"{"error":"Failed to create bitmap rep"}"#)
+                return
+            }
+
+            view.cacheDisplay(in: view.bounds, to: rep)
+
+            guard let pngData = rep.representation(using: .png, properties: [:]) else {
+                sendJSONResponse(connection: connection, status: "500 Internal Server Error",
+                                 body: #"{"error":"Failed to encode PNG"}"#)
+                return
+            }
+
+            sendBinaryResponse(connection: connection, status: "200 OK",
+                               contentType: "image/png", data: pngData)
+        }
+    }
+
+    // MARK: - Action
+
+    private func handleAction(body: String, connection: NWConnection) {
+        guard let jsonData = body.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let actionName = json["action"] as? String else {
+            sendJSONResponse(connection: connection, status: "400 Bad Request",
+                             body: #"{"error":"Missing or invalid 'action' field"}"#)
+            return
+        }
+
+        guard let actionKey = ActionDefinitions.ActionKey(rawValue: actionName) else {
+            sendJSONResponse(connection: connection, status: "400 Bad Request",
+                             body: "{\"error\":\"Unknown action: \(escapeJSON(actionName))\"}")
+            return
+        }
+
+        guard let vm = viewModel else {
+            sendJSONResponse(connection: connection, status: "503 Service Unavailable",
+                             body: #"{"error":"ViewModel not available"}"#)
+            return
+        }
+
+        DispatchQueue.main.sync {
+            if let actionInfo = vm.actionDefinitions.getActionInfo(actionKey) {
+                actionInfo.action()
+                sendJSONResponse(connection: connection, status: "200 OK",
+                                 body: "{\"success\":true,\"action\":\"\(escapeJSON(actionName))\"}")
+            } else if let toggleInfo = vm.actionDefinitions.getToggleActionInfo(actionKey) {
+                let newValue: Bool
+                if let explicitValue = json["value"] as? Bool {
+                    newValue = explicitValue
+                } else {
+                    newValue = !toggleInfo.isOn()
+                }
+                toggleInfo.action(newValue)
+                sendJSONResponse(connection: connection, status: "200 OK",
+                                 body: "{\"success\":true,\"action\":\"\(escapeJSON(actionName))\",\"isOn\":\(toggleInfo.isOn())}")
+            } else {
+                sendJSONResponse(connection: connection, status: "400 Bad Request",
+                                 body: "{\"error\":\"Action not registered: \(escapeJSON(actionName))\"}")
+            }
+        }
+    }
+
+    // MARK: - State
+
+    private func handleState(connection: NWConnection) {
+        guard let vm = viewModel else {
+            sendJSONResponse(connection: connection, status: "503 Service Unavailable",
+                             body: #"{"error":"ViewModel not available"}"#)
+            return
+        }
+
+        DispatchQueue.main.sync {
+            let state = buildStateJSON(vm)
+            sendJSONResponse(connection: connection, status: "200 OK", body: state)
+        }
+    }
+
+    private func buildStateJSON(_ vm: ViewModel) -> String {
+        let fen = escapeJSON(vm.currentFen)
+        let displayFen = escapeJSON(vm.displayFen)
+        let mode = escapeJSON(vm.currentAppMode.rawValue)
+        let comment = vm.currentFenComment.map { "\"\(escapeJSON($0))\"" } ?? "null"
+        let moveComment = vm.currentMoveComment.map { "\"\(escapeJSON($0))\"" } ?? "null"
+        let score = escapeJSON(vm.displayScore)
+        let engineScore = escapeJSON(vm.displayEngineScore)
+        let orientation = vm.isCurrentBlackOrientation ? "black" : "red"
+        let windowTitle = escapeJSON(vm.windowTitle)
+
+        let nextMoves = vm.currentNextMovesListDisplay.map { item in
+            "\"\(escapeJSON(item.moveString))\""
+        }.joined(separator: ",")
+
+        let variants = vm.currentGameVariantListDisplay.map { item in
+            "\"\(escapeJSON(item.moveString))\""
+        }.joined(separator: ",")
+
+        let filters = vm.currentFilters.map { "\"\(escapeJSON($0))\"" }.joined(separator: ",")
+
+        return "{\"fen\":\"\(fen)\",\"displayFen\":\"\(displayFen)\",\"mode\":\"\(mode)\","
+            + "\"step\":\(vm.currentGameStepDisplay),\"maxStep\":\(vm.maxGameStepDisplay),"
+            + "\"orientation\":\"\(orientation)\",\"isHorizontalFlipped\":\(vm.isCurrentHorizontalFlipped),"
+            + "\"comment\":\(comment),\"moveComment\":\(moveComment),"
+            + "\"score\":\"\(score)\",\"engineScore\":\"\(engineScore)\","
+            + "\"showPath\":\(vm.showPath),\"showAllNextMoves\":\(vm.showAllNextMoves),"
+            + "\"showLastMove\":\(vm.showLastMove),\"isLocked\":\(vm.isAnyMoveLocked),"
+            + "\"isBookmarked\":\(vm.isBookmarked),\"isInReview\":\(vm.isCurrentFenInReview),"
+            + "\"filters\":[\(filters)],\"nextMoves\":[\(nextMoves)],"
+            + "\"variants\":[\(variants)],\"windowTitle\":\"\(windowTitle)\"}"
+    }
+
+    // MARK: - List Actions
+
+    private func handleListActions(connection: NWConnection) {
+        let actions = ActionDefinitions.ActionKey.allCases.map { key in
+            "\"\(key.rawValue)\""
+        }.joined(separator: ",")
+        sendJSONResponse(connection: connection, status: "200 OK",
+                         body: "{\"actions\":[\(actions)]}")
+    }
+
+    // MARK: - Response Helpers
+
+    private func sendJSONResponse(connection: NWConnection, status: String, body: String) {
+        let response = "HTTP/1.1 \(status)\r\nContent-Type: application/json\r\nContent-Length: \(body.utf8.count)\r\nConnection: close\r\n\r\n\(body)"
+        let data = Data(response.utf8)
+        connection.send(content: data, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    private func sendBinaryResponse(connection: NWConnection, status: String,
+                                     contentType: String, data: Data) {
+        let header = "HTTP/1.1 \(status)\r\nContent-Type: \(contentType)\r\nContent-Length: \(data.count)\r\nConnection: close\r\n\r\n"
+        var responseData = Data(header.utf8)
+        responseData.append(data)
+        connection.send(content: responseData, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    private func escapeJSON(_ str: String) -> String {
+        str.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+    }
+}
+#endif
+#endif

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -7,6 +7,9 @@ struct MacContentView: View {
     @StateObject private var viewModel: ViewModel
     @FocusState private var isViewFocused: Bool
     @State private var keyMonitor: Any?
+    #if DEBUG
+    @State private var remoteControlServer: RemoteControlServer?
+    #endif
     
     init() {
         _viewModel = StateObject(wrappedValue: ViewModel(
@@ -168,9 +171,16 @@ struct MacContentView: View {
         .onAppear {
             updateWindowTitle()
             installKeyMonitor()
+            #if DEBUG
+            startRemoteControlServer()
+            #endif
         }
         .onDisappear {
             removeKeyMonitor()
+            #if DEBUG
+            remoteControlServer?.stop()
+            remoteControlServer = nil
+            #endif
         }
         .onReceive(viewModel.objectWillChange) { _ in
             // 监听 ViewModel 的任何变化，及时更新窗口标题
@@ -236,6 +246,20 @@ struct MacContentView: View {
             keyMonitor = nil
         }
     }
+
+    #if DEBUG
+    private func startRemoteControlServer() {
+        let server = RemoteControlServer()
+        server.viewModel = viewModel
+        do {
+            try server.start()
+            remoteControlServer = server
+            print("RemoteControlServer started on port 9214")
+        } catch {
+            print("RemoteControlServer failed to start: \(error)")
+        }
+    }
+    #endif
 
     /// 更新窗口标题
     private func updateWindowTitle() {


### PR DESCRIPTION
## Summary

- 新建 `RemoteControlServer` 类，在 DEBUG 构建下监听 `localhost:9214`
- 提供 4 个 HTTP API 端点：
  - `GET /screenshot` — 截图当前窗口返回 PNG（使用 `NSView.cacheDisplay`）
  - `POST /action` — 执行任意 ActionKey 操作（支持普通操作和 toggle）
  - `GET /state` — 返回当前应用状态 JSON（FEN、mode、step、orientation、nextMoves、variants 等）
  - `GET /actions` — 列出所有可用操作
- 集成到 `MacContentView` 中，`onAppear` 启动、`onDisappear` 停止
- 更新 `CLAUDE.md` 新增「远程操控与 UI 验证」章节，指导 Claude Code 在修改 UI 后通过截图接口进行视觉验证

Closes #57

## Test Plan

- [x] DEBUG 构建通过
- [x] 全部单元测试通过（无回归）
- [x] 手动验证 API 接口工作正常：
  - `curl http://localhost:9214/actions` 返回操作列表
  - `curl http://localhost:9214/state` 返回当前状态 JSON
  - `curl -X POST http://localhost:9214/action -d '{"action":"stepForward"}'` 执行操作
  - `curl http://localhost:9214/screenshot -o /tmp/screenshot.png` 获取截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)