### PR TITLE
修复课程书籍查找方式：用 courseBookId 替代按名称匹配

### DIFF
--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -160,13 +160,11 @@ class Session: ObservableObject {
     var relatedCoursesForCurrentFen: [GameObject] {
         let currentFenId = self.currentFenId
 
-        // 查找名为"课程"的 BookObject
-        guard let courseBook = databaseView.getAllBookObjectsUnfiltered().first(where: { $0.name == "课程" }) else {
+        guard databaseView.getBookObjectUnfiltered(Session.courseBookId) != nil else {
             return []
         }
 
-        // 获取"课程"及其所有子书籍中的游戏
-        let allGames = databaseView.getGamesInBookRecursivelyUnfiltered(bookId: courseBook.id)
+        let allGames = databaseView.getGamesInBookRecursivelyUnfiltered(bookId: Session.courseBookId)
 
         // 过滤出包含当前 fenId 的游戏
         return allGames.filter { game in
@@ -781,8 +779,8 @@ class Session: ObservableObject {
         }
 
         if let fenId = fenObject?.fenId,
-           let courseBook = databaseView.getAllBookObjectsUnfiltered().first(where: { $0.name == "课程" }) {
-            let allGames = databaseView.getGamesInBookRecursivelyUnfiltered(bookId: courseBook.id)
+           databaseView.getBookObjectUnfiltered(Session.courseBookId) != nil {
+            let allGames = databaseView.getGamesInBookRecursivelyUnfiltered(bookId: Session.courseBookId)
             let relatedCourses = allGames.filter { game in
                 databaseView.gameContainsFenId(gameId: game.id, fenId: fenId)
             }


### PR DESCRIPTION
## Summary
- 课程书籍查找从按名称匹配 `"课程"` 改为按 `courseBookId` 常量查找
- 修复当存在多个同名"课程"书籍时，`relatedCoursesForCurrentFen` 和 `getCombinedComment` 查找结果不确定的问题

## Test plan
- [x] RelatedCoursesTests 全部通过
- [x] 完整测试套件通过
- [x] 实际运行 app 验证棋谱列表中课程书籍显示正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)