### PR TITLE
macOS 主页面左侧添加棋局浏览器侧栏

### DIFF
--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -521,6 +521,10 @@ class Session: ObservableObject {
         sessionData.showRealGameList
     }
 
+    var showGameBrowserSidebar: Bool {
+        sessionData.showGameBrowserSidebar
+    }
+
     var isCommentEditing: Bool {
         sessionData.isCommentEditing
     }
@@ -1057,6 +1061,11 @@ extension Session {
 
     func toggleShowRealGameList() {
         sessionData.showRealGameList.toggle()
+        notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
+    }
+
+    func toggleShowGameBrowserSidebar() {
+        sessionData.showGameBrowserSidebar.toggle()
         notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
     }
 

--- a/XiangqiNotebook/Models/Session.swift
+++ b/XiangqiNotebook/Models/Session.swift
@@ -521,10 +521,6 @@ class Session: ObservableObject {
         sessionData.showRealGameList
     }
 
-    var showGameBrowserSidebar: Bool {
-        sessionData.showGameBrowserSidebar
-    }
-
     var isCommentEditing: Bool {
         sessionData.isCommentEditing
     }
@@ -1061,11 +1057,6 @@ extension Session {
 
     func toggleShowRealGameList() {
         sessionData.showRealGameList.toggle()
-        notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
-    }
-
-    func toggleShowGameBrowserSidebar() {
-        sessionData.showGameBrowserSidebar.toggle()
         notifyDataChanged(markDatabaseDirty: false, markSessionDirty: true)
     }
 

--- a/XiangqiNotebook/Models/SessionData.swift
+++ b/XiangqiNotebook/Models/SessionData.swift
@@ -21,6 +21,7 @@ class SessionData: Codable {
     var specificGameId: UUID? = nil
     var specificBookId: UUID? = nil
     var allowAddingNewMoves: Bool = true
+    var showGameBrowserSidebar: Bool = false
     var gameBrowserExpandedBookIds: Set<UUID>? = nil
     var gameBrowserSelectedBookId: UUID? = nil
     var gameBrowserSelectedGameId: UUID? = nil
@@ -55,6 +56,7 @@ class SessionData: Codable {
         case specificGameId = "specific_game_id"
         case specificBookId = "specific_book_id"
         case allowAddingNewMoves = "allow_adding_new_moves"
+        case showGameBrowserSidebar = "show_game_browser_sidebar"
         case gameBrowserExpandedBookIds = "game_browser_expanded_book_ids"
         case gameBrowserSelectedBookId = "game_browser_selected_book_id"
         case gameBrowserSelectedGameId = "game_browser_selected_game_id"
@@ -89,6 +91,7 @@ class SessionData: Codable {
             currentMode = AppMode(rawValue: modeString) ?? .normal
         }
         allowAddingNewMoves = try container.decodeIfPresent(Bool.self, forKey: .allowAddingNewMoves) ?? true
+        showGameBrowserSidebar = try container.decodeIfPresent(Bool.self, forKey: .showGameBrowserSidebar) ?? false
         gameBrowserExpandedBookIds = try container.decodeIfPresent(Set<UUID>.self, forKey: .gameBrowserExpandedBookIds)
         gameBrowserSelectedBookId = try container.decodeIfPresent(UUID.self, forKey: .gameBrowserSelectedBookId)
         gameBrowserSelectedGameId = try container.decodeIfPresent(UUID.self, forKey: .gameBrowserSelectedGameId)
@@ -117,6 +120,7 @@ class SessionData: Codable {
         try container.encodeIfPresent(specificBookId, forKey: .specificBookId)
         try container.encode(currentMode, forKey: .currentMode)
         try container.encode(allowAddingNewMoves, forKey: .allowAddingNewMoves)
+        try container.encode(showGameBrowserSidebar, forKey: .showGameBrowserSidebar)
         try container.encodeIfPresent(gameBrowserExpandedBookIds, forKey: .gameBrowserExpandedBookIds)
         try container.encodeIfPresent(gameBrowserSelectedBookId, forKey: .gameBrowserSelectedBookId)
         try container.encodeIfPresent(gameBrowserSelectedGameId, forKey: .gameBrowserSelectedGameId)

--- a/XiangqiNotebook/Models/SessionData.swift
+++ b/XiangqiNotebook/Models/SessionData.swift
@@ -21,7 +21,6 @@ class SessionData: Codable {
     var specificGameId: UUID? = nil
     var specificBookId: UUID? = nil
     var allowAddingNewMoves: Bool = true
-    var showGameBrowserSidebar: Bool = false
     var gameBrowserExpandedBookIds: Set<UUID>? = nil
     var gameBrowserSelectedBookId: UUID? = nil
     var gameBrowserSelectedGameId: UUID? = nil
@@ -56,7 +55,6 @@ class SessionData: Codable {
         case specificGameId = "specific_game_id"
         case specificBookId = "specific_book_id"
         case allowAddingNewMoves = "allow_adding_new_moves"
-        case showGameBrowserSidebar = "show_game_browser_sidebar"
         case gameBrowserExpandedBookIds = "game_browser_expanded_book_ids"
         case gameBrowserSelectedBookId = "game_browser_selected_book_id"
         case gameBrowserSelectedGameId = "game_browser_selected_game_id"
@@ -91,7 +89,6 @@ class SessionData: Codable {
             currentMode = AppMode(rawValue: modeString) ?? .normal
         }
         allowAddingNewMoves = try container.decodeIfPresent(Bool.self, forKey: .allowAddingNewMoves) ?? true
-        showGameBrowserSidebar = try container.decodeIfPresent(Bool.self, forKey: .showGameBrowserSidebar) ?? false
         gameBrowserExpandedBookIds = try container.decodeIfPresent(Set<UUID>.self, forKey: .gameBrowserExpandedBookIds)
         gameBrowserSelectedBookId = try container.decodeIfPresent(UUID.self, forKey: .gameBrowserSelectedBookId)
         gameBrowserSelectedGameId = try container.decodeIfPresent(UUID.self, forKey: .gameBrowserSelectedGameId)
@@ -120,7 +117,6 @@ class SessionData: Codable {
         try container.encodeIfPresent(specificBookId, forKey: .specificBookId)
         try container.encode(currentMode, forKey: .currentMode)
         try container.encode(allowAddingNewMoves, forKey: .allowAddingNewMoves)
-        try container.encode(showGameBrowserSidebar, forKey: .showGameBrowserSidebar)
         try container.encodeIfPresent(gameBrowserExpandedBookIds, forKey: .gameBrowserExpandedBookIds)
         try container.encodeIfPresent(gameBrowserSelectedBookId, forKey: .gameBrowserSelectedBookId)
         try container.encodeIfPresent(gameBrowserSelectedGameId, forKey: .gameBrowserSelectedGameId)

--- a/XiangqiNotebook/Models/SessionManager.swift
+++ b/XiangqiNotebook/Models/SessionManager.swift
@@ -103,6 +103,10 @@ class SessionManager: ObservableObject {
         newSessionData.autoExtendGameWhenPlayingBoardFen = mainSession.sessionData.autoExtendGameWhenPlayingBoardFen
         newSessionData.isCommentEditing = mainSession.sessionData.isCommentEditing
         newSessionData.focusedPracticeGamePath = focusedPath
+        newSessionData.showGameBrowserSidebar = mainSession.sessionData.showGameBrowserSidebar
+        newSessionData.gameBrowserExpandedBookIds = mainSession.sessionData.gameBrowserExpandedBookIds
+        newSessionData.gameBrowserSelectedBookId = mainSession.sessionData.gameBrowserSelectedBookId
+        newSessionData.gameBrowserSelectedGameId = mainSession.sessionData.gameBrowserSelectedGameId
         // 保留上一次的 specificGameId/specificBookId，除非明确传入了新值
         newSessionData.specificGameId = specificGameId ?? mainSession.sessionData.specificGameId
         newSessionData.specificBookId = specificBookId ?? mainSession.sessionData.specificBookId

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -40,7 +40,6 @@ class ActionDefinitions {
         case stepLimitation  // 新增：步数限制按钮
         case inputGame  // 新增：录入棋局按钮
         case browseGames  // 新增：棋局浏览器按钮
-        case toggleGameBrowserSidebar
         case playRandomNextMove  // 新增：随机走法按钮
         case hintNextMove       // 新增：提示按钮
         case reviewThisGame

--- a/XiangqiNotebook/ViewModels/ActionDefinitions.swift
+++ b/XiangqiNotebook/ViewModels/ActionDefinitions.swift
@@ -40,6 +40,7 @@ class ActionDefinitions {
         case stepLimitation  // 新增：步数限制按钮
         case inputGame  // 新增：录入棋局按钮
         case browseGames  // 新增：棋局浏览器按钮
+        case toggleGameBrowserSidebar
         case playRandomNextMove  // 新增：随机走法按钮
         case hintNextMove       // 新增：提示按钮
         case reviewThisGame

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -332,7 +332,7 @@ class ViewModel: ObservableObject {
 
         actionDefinitions.registerAction(.stepLimitation, text: "步数限制", supportedModes: [.normal]) { self.showingStepLimitationDialog = true }
         actionDefinitions.registerAction(.inputGame, text: "录入棋局", shortcuts: [.sequence(",i")], supportedModes: [.normal]) { self.showingGameInputView = true }
-        actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",gb")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
+        actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",gB")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
         actionDefinitions.registerAction(.importPGN, text: "导入PGN", shortcuts: [.sequence(",pi")], supportedModes: [.normal]) { self.showingPGNImportSheet = true }
         actionDefinitions.registerAction(.exportPGNCurrentDatabaseView, text: "导出所有变着PGN...", shortcuts: [.sequence(",pa")], supportedModes: [.normal]) { self.exportPGNCurrentDatabaseView() }
         actionDefinitions.registerAction(.exportPGNCurrentGame, text: "导出当前棋局PGN...", shortcuts: [.sequence(",pc")], supportedModes: [.normal]) { self.exportPGNCurrentGame() }
@@ -635,6 +635,20 @@ class ViewModel: ObservableObject {
             self.toggleShowRealGameList()
           }
         )
+
+        #if os(macOS)
+        actionDefinitions.registerToggleAction(
+          .toggleGameBrowserSidebar,
+          text: "棋局浏览器侧栏",
+          shortcuts: [.sequence(",gb")],
+          supportedModes: [.normal],
+          isEnabled: { true },
+          isOn: { self.showGameBrowserSidebar },
+          action: { _ in
+            self.toggleShowGameBrowserSidebar()
+          }
+        )
+        #endif
 
         // 书签功能 - 只在常规模式可用
         actionDefinitions.registerToggleAction(
@@ -2104,6 +2118,7 @@ class ViewModel: ObservableObject {
     var showAllNextMoves: Bool { session.showAllNextMoves }
     var showLastMove: Bool { session.showLastMove }
     var showRealGameList: Bool { session.showRealGameList }
+    var showGameBrowserSidebar: Bool { session.showGameBrowserSidebar }
     var isCommentEditing: Bool { session.isCommentEditing }
     var currentDataVersion: Int { session.currentDataVersion }
     var currentDataDirty: Bool { session.currentDataDirty }
@@ -2318,6 +2333,10 @@ class ViewModel: ObservableObject {
 
     func toggleShowRealGameList() {
         session.toggleShowRealGameList()
+    }
+
+    func toggleShowGameBrowserSidebar() {
+        session.toggleShowGameBrowserSidebar()
     }
 
     func setDataClean() {

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -332,7 +332,7 @@ class ViewModel: ObservableObject {
 
         actionDefinitions.registerAction(.stepLimitation, text: "步数限制", supportedModes: [.normal]) { self.showingStepLimitationDialog = true }
         actionDefinitions.registerAction(.inputGame, text: "录入棋局", shortcuts: [.sequence(",i")], supportedModes: [.normal]) { self.showingGameInputView = true }
-        actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",gB")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
+        actionDefinitions.registerAction(.browseGames, text: "棋局浏览器", shortcuts: [.sequence(",gb")], supportedModes: [.normal]) { self.showingGameBrowserView = true }
         actionDefinitions.registerAction(.importPGN, text: "导入PGN", shortcuts: [.sequence(",pi")], supportedModes: [.normal]) { self.showingPGNImportSheet = true }
         actionDefinitions.registerAction(.exportPGNCurrentDatabaseView, text: "导出所有变着PGN...", shortcuts: [.sequence(",pa")], supportedModes: [.normal]) { self.exportPGNCurrentDatabaseView() }
         actionDefinitions.registerAction(.exportPGNCurrentGame, text: "导出当前棋局PGN...", shortcuts: [.sequence(",pc")], supportedModes: [.normal]) { self.exportPGNCurrentGame() }
@@ -635,20 +635,6 @@ class ViewModel: ObservableObject {
             self.toggleShowRealGameList()
           }
         )
-
-        #if os(macOS)
-        actionDefinitions.registerToggleAction(
-          .toggleGameBrowserSidebar,
-          text: "棋局浏览器侧栏",
-          shortcuts: [.sequence(",gb")],
-          supportedModes: [.normal],
-          isEnabled: { true },
-          isOn: { self.showGameBrowserSidebar },
-          action: { _ in
-            self.toggleShowGameBrowserSidebar()
-          }
-        )
-        #endif
 
         // 书签功能 - 只在常规模式可用
         actionDefinitions.registerToggleAction(
@@ -2118,7 +2104,6 @@ class ViewModel: ObservableObject {
     var showAllNextMoves: Bool { session.showAllNextMoves }
     var showLastMove: Bool { session.showLastMove }
     var showRealGameList: Bool { session.showRealGameList }
-    var showGameBrowserSidebar: Bool { session.showGameBrowserSidebar }
     var isCommentEditing: Bool { session.isCommentEditing }
     var currentDataVersion: Int { session.currentDataVersion }
     var currentDataDirty: Bool { session.currentDataDirty }
@@ -2333,10 +2318,6 @@ class ViewModel: ObservableObject {
 
     func toggleShowRealGameList() {
         session.toggleShowRealGameList()
-    }
-
-    func toggleShowGameBrowserSidebar() {
-        session.toggleShowGameBrowserSidebar()
     }
 
     func setDataClean() {

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1134,15 +1134,10 @@ private enum SidebarRow: Identifiable {
     }
 }
 
-private class SidebarSelection: ObservableObject {
-    @Published var gameId: UUID?
-}
-
 struct GameBrowserSidebarView: View {
     @ObservedObject var viewModel: ViewModel
     @State private var expandedBookIds: Set<UUID>?
-    @StateObject private var selection = SidebarSelection()
-    @State private var cachedRows: [SidebarRow] = []
+    @State private var selectedGameId: UUID?
 
     private func isBookExpanded(_ bookId: UUID) -> Bool {
         guard let ids = expandedBookIds else { return true }
@@ -1150,7 +1145,6 @@ struct GameBrowserSidebarView: View {
     }
 
     private func toggleBookExpanded(_ bookId: UUID) {
-        let wasExpanded = isBookExpanded(bookId)
         if expandedBookIds == nil {
             var allIds = Set(viewModel.allBookObjects.map { $0.id })
             allIds.remove(bookId)
@@ -1159,66 +1153,6 @@ struct GameBrowserSidebarView: View {
             expandedBookIds!.remove(bookId)
         } else {
             expandedBookIds!.insert(bookId)
-        }
-
-        guard let bookIndex = cachedRows.firstIndex(where: {
-            if case .book(let b, _, _, _) = $0 { return b.id == bookId }
-            return false
-        }) else { return }
-
-        if wasExpanded {
-            collapseBookAt(bookIndex)
-        } else {
-            expandBookAt(bookIndex)
-        }
-    }
-
-    private func collapseBookAt(_ index: Int) {
-        guard case .book(let book, let level, _, let hasChildren) = cachedRows[index] else { return }
-        cachedRows[index] = .book(book, level: level, isExpanded: false, hasChildren: hasChildren)
-
-        var removeCount = 0
-        let startIndex = index + 1
-        while startIndex + removeCount < cachedRows.count {
-            let row = cachedRows[startIndex + removeCount]
-            let rowLevel: Int
-            switch row {
-            case .book(_, let l, _, _): rowLevel = l
-            case .game(_, let l): rowLevel = l
-            }
-            if rowLevel <= level { break }
-            removeCount += 1
-        }
-        if removeCount > 0 {
-            cachedRows.removeSubrange(startIndex..<(startIndex + removeCount))
-        }
-    }
-
-    private func expandBookAt(_ index: Int) {
-        guard case .book(let book, let level, _, let hasChildren) = cachedRows[index] else { return }
-        cachedRows[index] = .book(book, level: level, isExpanded: true, hasChildren: hasChildren)
-
-        var newRows: [SidebarRow] = []
-        buildChildRows(for: book, level: level + 1, into: &newRows)
-        if !newRows.isEmpty {
-            cachedRows.insert(contentsOf: newRows, at: index + 1)
-        }
-    }
-
-    private func buildChildRows(for book: BookObject, level: Int, into rows: inout [SidebarRow]) {
-        let subBooks = book.subBookIds.compactMap { subId in
-            viewModel.allBookObjects.first { $0.id == subId }
-        }
-        for subBook in subBooks {
-            let expanded = isBookExpanded(subBook.id)
-            let hasChildren = !subBook.subBookIds.isEmpty || !subBook.gameIds.isEmpty
-            rows.append(.book(subBook, level: level, isExpanded: expanded, hasChildren: hasChildren))
-            if expanded {
-                buildChildRows(for: subBook, level: level + 1, into: &rows)
-            }
-        }
-        for game in gamesInBook(book.id) {
-            rows.append(.game(game, level: level))
         }
     }
 
@@ -1235,7 +1169,7 @@ struct GameBrowserSidebarView: View {
         return allGames
     }
 
-    private func rebuildRows() {
+    private var visibleRows: [SidebarRow] {
         var rows: [SidebarRow] = []
         func walk(_ books: [BookObject], level: Int) {
             for book in books {
@@ -1243,12 +1177,18 @@ struct GameBrowserSidebarView: View {
                 let hasChildren = !book.subBookIds.isEmpty || !book.gameIds.isEmpty
                 rows.append(.book(book, level: level, isExpanded: expanded, hasChildren: hasChildren))
                 if expanded {
-                    buildChildRows(for: book, level: level + 1, into: &rows)
+                    let subBooks = book.subBookIds.compactMap { subId in
+                        viewModel.allBookObjects.first { $0.id == subId }
+                    }
+                    walk(subBooks, level: level + 1)
+                    for game in gamesInBook(book.id) {
+                        rows.append(.game(game, level: level + 1))
+                    }
                 }
             }
         }
         walk(viewModel.allTopLevelBookObjects, level: 0)
-        cachedRows = rows
+        return rows
     }
 
     var body: some View {
@@ -1263,7 +1203,7 @@ struct GameBrowserSidebarView: View {
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 2) {
-                    ForEach(cachedRows) { row in
+                    ForEach(visibleRows) { row in
                         switch row {
                         case .book(let book, let level, let isExpanded, let hasChildren):
                             SidebarBookRowView(
@@ -1277,8 +1217,13 @@ struct GameBrowserSidebarView: View {
                             SidebarGameRowView(
                                 game: game,
                                 level: level,
-                                selection: selection,
+                                isSelected: selectedGameId == game.id,
                                 isCurrentGame: viewModel.currentSpecificGameId == game.id,
+                                onSelect: {
+                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                        selectedGameId = selectedGameId == game.id ? nil : game.id
+                                    }
+                                },
                                 onLoad: { viewModel.loadGame(game.id) }
                             )
                         }
@@ -1290,13 +1235,9 @@ struct GameBrowserSidebarView: View {
         .background(Color.adaptiveBackground)
         .onAppear {
             expandedBookIds = viewModel.session.sessionData.gameBrowserExpandedBookIds
-            rebuildRows()
         }
         .onChange(of: expandedBookIds) {
             viewModel.session.sessionData.gameBrowserExpandedBookIds = expandedBookIds
-        }
-        .onReceive(viewModel.session.$dataChanged) { _ in
-            rebuildRows()
         }
     }
 }
@@ -1356,13 +1297,10 @@ private struct SidebarBookRowView: View {
 private struct SidebarGameRowView: View {
     let game: GameObject
     let level: Int
-    @ObservedObject var selection: SidebarSelection
+    let isSelected: Bool
     let isCurrentGame: Bool
+    let onSelect: () -> Void
     let onLoad: () -> Void
-
-    private var isSelected: Bool {
-        selection.gameId == game.id
-    }
 
     private let indentWidth: CGFloat = 16
 
@@ -1446,9 +1384,7 @@ private struct SidebarGameRowView: View {
         )
         .contentShape(Rectangle())
         .onTapGesture {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                selection.gameId = isSelected ? nil : game.id
-            }
+            onSelect()
         }
     }
 }

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1146,6 +1146,7 @@ struct GameBrowserSidebarView: View {
     }
 
     private func toggleBookExpanded(_ bookId: UUID) {
+        let wasExpanded = isBookExpanded(bookId)
         if expandedBookIds == nil {
             var allIds = Set(viewModel.allBookObjects.map { $0.id })
             allIds.remove(bookId)
@@ -1154,6 +1155,66 @@ struct GameBrowserSidebarView: View {
             expandedBookIds!.remove(bookId)
         } else {
             expandedBookIds!.insert(bookId)
+        }
+
+        guard let bookIndex = cachedRows.firstIndex(where: {
+            if case .book(let b, _, _, _) = $0 { return b.id == bookId }
+            return false
+        }) else { return }
+
+        if wasExpanded {
+            collapseBookAt(bookIndex)
+        } else {
+            expandBookAt(bookIndex)
+        }
+    }
+
+    private func collapseBookAt(_ index: Int) {
+        guard case .book(let book, let level, _, let hasChildren) = cachedRows[index] else { return }
+        cachedRows[index] = .book(book, level: level, isExpanded: false, hasChildren: hasChildren)
+
+        var removeCount = 0
+        let startIndex = index + 1
+        while startIndex + removeCount < cachedRows.count {
+            let row = cachedRows[startIndex + removeCount]
+            let rowLevel: Int
+            switch row {
+            case .book(_, let l, _, _): rowLevel = l
+            case .game(_, let l): rowLevel = l
+            }
+            if rowLevel <= level { break }
+            removeCount += 1
+        }
+        if removeCount > 0 {
+            cachedRows.removeSubrange(startIndex..<(startIndex + removeCount))
+        }
+    }
+
+    private func expandBookAt(_ index: Int) {
+        guard case .book(let book, let level, _, let hasChildren) = cachedRows[index] else { return }
+        cachedRows[index] = .book(book, level: level, isExpanded: true, hasChildren: hasChildren)
+
+        var newRows: [SidebarRow] = []
+        buildChildRows(for: book, level: level + 1, into: &newRows)
+        if !newRows.isEmpty {
+            cachedRows.insert(contentsOf: newRows, at: index + 1)
+        }
+    }
+
+    private func buildChildRows(for book: BookObject, level: Int, into rows: inout [SidebarRow]) {
+        let subBooks = book.subBookIds.compactMap { subId in
+            viewModel.allBookObjects.first { $0.id == subId }
+        }
+        for subBook in subBooks {
+            let expanded = isBookExpanded(subBook.id)
+            let hasChildren = !subBook.subBookIds.isEmpty || !subBook.gameIds.isEmpty
+            rows.append(.book(subBook, level: level, isExpanded: expanded, hasChildren: hasChildren))
+            if expanded {
+                buildChildRows(for: subBook, level: level + 1, into: &rows)
+            }
+        }
+        for game in gamesInBook(book.id) {
+            rows.append(.game(game, level: level))
         }
     }
 
@@ -1178,13 +1239,7 @@ struct GameBrowserSidebarView: View {
                 let hasChildren = !book.subBookIds.isEmpty || !book.gameIds.isEmpty
                 rows.append(.book(book, level: level, isExpanded: expanded, hasChildren: hasChildren))
                 if expanded {
-                    let subBooks = book.subBookIds.compactMap { subId in
-                        viewModel.allBookObjects.first { $0.id == subId }
-                    }
-                    walk(subBooks, level: level + 1)
-                    for game in gamesInBook(book.id) {
-                        rows.append(.game(game, level: level + 1))
-                    }
+                    buildChildRows(for: book, level: level + 1, into: &rows)
                 }
             }
         }
@@ -1240,7 +1295,6 @@ struct GameBrowserSidebarView: View {
         }
         .onChange(of: expandedBookIds) {
             viewModel.session.sessionData.gameBrowserExpandedBookIds = expandedBookIds
-            rebuildRows()
         }
         .onReceive(viewModel.session.$dataChanged) { _ in
             rebuildRows()

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1445,9 +1445,6 @@ private struct SidebarGameRowView: View {
                 .fill(isCurrentGame ? Color.accentColor.opacity(0.2) : (isSelected ? Color.secondary.opacity(0.1) : Color.clear))
         )
         .contentShape(Rectangle())
-        .onTapGesture(count: 2) {
-            onLoad()
-        }
         .onTapGesture {
             withAnimation(.easeInOut(duration: 0.15)) {
                 selection.gameId = isSelected ? nil : game.id

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1205,7 +1205,7 @@ struct SidebarBookNodeView: View {
     }
 
     private var hasChildren: Bool {
-        !subBooks.isEmpty || !games.isEmpty
+        !book.subBookIds.isEmpty || !book.gameIds.isEmpty
     }
 
     var body: some View {

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1124,6 +1124,7 @@ struct GameActionSection: View {
 struct GameBrowserSidebarView: View {
     @ObservedObject var viewModel: ViewModel
     @State private var expandedBookIds: Set<UUID>?
+    @State private var selectedGameId: UUID?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -1142,6 +1143,7 @@ struct GameBrowserSidebarView: View {
                             book: book,
                             viewModel: viewModel,
                             expandedBookIds: $expandedBookIds,
+                            selectedGameId: $selectedGameId,
                             level: 0
                         )
                     }
@@ -1163,6 +1165,7 @@ struct SidebarBookNodeView: View {
     let book: BookObject
     @ObservedObject var viewModel: ViewModel
     @Binding var expandedBookIds: Set<UUID>?
+    @Binding var selectedGameId: UUID?
     let level: Int
 
     private var isExpanded: Bool {
@@ -1255,12 +1258,13 @@ struct SidebarBookNodeView: View {
                         book: subBook,
                         viewModel: viewModel,
                         expandedBookIds: $expandedBookIds,
+                        selectedGameId: $selectedGameId,
                         level: level + 1
                     )
                 }
 
                 ForEach(games) { game in
-                    SidebarGameItemView(game: game, viewModel: viewModel, level: level + 1)
+                    SidebarGameItemView(game: game, viewModel: viewModel, level: level + 1, selectedGameId: $selectedGameId)
                         .id(game.id)
                 }
             }
@@ -1272,42 +1276,104 @@ struct SidebarGameItemView: View {
     let game: GameObject
     @ObservedObject var viewModel: ViewModel
     let level: Int
+    @Binding var selectedGameId: UUID?
 
     private var isCurrentGame: Bool {
         viewModel.currentSpecificGameId == game.id
     }
 
+    private var isSelected: Bool {
+        selectedGameId == game.id
+    }
+
+    private let indentWidth: CGFloat = 16
+
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(0..<level, id: \.self) { _ in
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach(0..<level, id: \.self) { _ in
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: indentWidth)
+                }
+
                 Rectangle()
                     .fill(Color.clear)
-                    .frame(width: 16)
+                    .frame(width: indentWidth)
+
+                HStack(spacing: 6) {
+                    Image(systemName: "doc.text")
+                        .foregroundColor(.orange)
+                        .font(.system(size: 11))
+                    Text(game.displayTitle)
+                        .font(.system(size: 12, weight: isSelected ? .medium : .regular))
+                        .lineLimit(1)
+                    Spacer()
+                }
             }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 3)
 
-            Rectangle()
-                .fill(Color.clear)
-                .frame(width: 16)
+            if isSelected {
+                HStack(spacing: 0) {
+                    ForEach(0..<(level + 1), id: \.self) { _ in
+                        Rectangle()
+                            .fill(Color.clear)
+                            .frame(width: indentWidth)
+                    }
 
-            HStack(spacing: 6) {
-                Image(systemName: "doc.text")
-                    .foregroundColor(.orange)
-                    .font(.system(size: 11))
-                Text(game.displayTitle)
-                    .font(.system(size: 12))
-                    .lineLimit(1)
-                Spacer()
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: indentWidth)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        if !game.redPlayerName.isEmpty || !game.blackPlayerName.isEmpty {
+                            Text("\(game.redPlayerName.isEmpty ? "?" : game.redPlayerName) vs \(game.blackPlayerName.isEmpty ? "?" : game.blackPlayerName)")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                        }
+
+                        HStack(spacing: 6) {
+                            if let date = game.gameDate {
+                                Text(date, style: .date)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+
+                            if game.gameResult != .unknown {
+                                Text(game.gameResult.rawValue)
+                                    .font(.system(size: 10, weight: .medium))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+
+                        Button(action: { viewModel.loadGame(game.id) }) {
+                            Text("加载棋局")
+                                .font(.system(size: 11))
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.accentColor)
+                        .padding(.top, 1)
+                    }
+                    .padding(.bottom, 4)
+
+                    Spacer()
+                }
+                .padding(.horizontal, 4)
             }
         }
-        .padding(.horizontal, 4)
-        .padding(.vertical, 3)
         .background(
             RoundedRectangle(cornerRadius: 4)
-                .fill(isCurrentGame ? Color.accentColor.opacity(0.2) : Color.clear)
+                .fill(isCurrentGame ? Color.accentColor.opacity(0.2) : (isSelected ? Color.secondary.opacity(0.1) : Color.clear))
         )
         .contentShape(Rectangle())
-        .onTapGesture {
+        .onTapGesture(count: 2) {
             viewModel.loadGame(game.id)
+        }
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                selectedGameId = isSelected ? nil : game.id
+            }
         }
     }
 }

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1123,33 +1123,35 @@ struct GameActionSection: View {
 #if os(macOS)
 struct GameBrowserSidebarView: View {
     @ObservedObject var viewModel: ViewModel
-    @State private var selectedBookId: UUID?
     @State private var expandedBookIds: Set<UUID>?
 
     var body: some View {
-        VStack(spacing: 0) {
-            BookTreeSidebarView(
-                viewModel: viewModel,
-                selectedBookId: $selectedBookId,
-                expandedBookIds: $expandedBookIds,
-                showingPGNImportSheet: .constant(false)
-            )
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("棋局浏览器")
+                    .font(.headline)
+                    .padding(.horizontal)
+                    .padding(.top)
+                Spacer()
+            }
 
-            Divider()
-
-            SidebarGameListView(
-                viewModel: viewModel,
-                selectedBookId: selectedBookId
-            )
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(viewModel.allTopLevelBookObjects) { book in
+                        SidebarBookNodeView(
+                            book: book,
+                            viewModel: viewModel,
+                            expandedBookIds: $expandedBookIds,
+                            level: 0
+                        )
+                    }
+                }
+                .padding(.horizontal)
+            }
         }
         .background(Color.adaptiveBackground)
         .onAppear {
-            let sessionData = viewModel.session.sessionData
-            expandedBookIds = sessionData.gameBrowserExpandedBookIds
-            selectedBookId = sessionData.gameBrowserSelectedBookId
-        }
-        .onChange(of: selectedBookId) {
-            viewModel.session.sessionData.gameBrowserSelectedBookId = selectedBookId
+            expandedBookIds = viewModel.session.sessionData.gameBrowserExpandedBookIds
         }
         .onChange(of: expandedBookIds) {
             viewModel.session.sessionData.gameBrowserExpandedBookIds = expandedBookIds
@@ -1157,18 +1159,37 @@ struct GameBrowserSidebarView: View {
     }
 }
 
-struct SidebarGameListView: View {
+struct SidebarBookNodeView: View {
+    let book: BookObject
     @ObservedObject var viewModel: ViewModel
-    let selectedBookId: UUID?
+    @Binding var expandedBookIds: Set<UUID>?
+    let level: Int
 
-    private var selectedBook: BookObject? {
-        guard let bookId = selectedBookId else { return nil }
-        return viewModel.allBookObjects.first { $0.id == bookId }
+    private var isExpanded: Bool {
+        guard let ids = expandedBookIds else { return true }
+        return ids.contains(book.id)
+    }
+
+    private func toggleExpanded() {
+        if expandedBookIds == nil {
+            var allIds = Set(viewModel.allBookObjects.map { $0.id })
+            allIds.remove(book.id)
+            expandedBookIds = allIds
+        } else if expandedBookIds!.contains(book.id) {
+            expandedBookIds!.remove(book.id)
+        } else {
+            expandedBookIds!.insert(book.id)
+        }
+    }
+
+    private var subBooks: [BookObject] {
+        book.subBookIds.compactMap { subBookId in
+            viewModel.allBookObjects.first { $0.id == subBookId }
+        }
     }
 
     private var games: [GameObject] {
-        guard let bookId = selectedBookId else { return [] }
-        let allGames = viewModel.getGamesInBook(bookId)
+        let allGames = viewModel.getGamesInBook(book.id)
         let hasRealGames = allGames.contains { $0.iAmRed || $0.iAmBlack }
         if hasRealGames {
             return allGames.sorted { g1, g2 in
@@ -1180,61 +1201,67 @@ struct SidebarGameListView: View {
         return allGames
     }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if let book = selectedBook {
-                HStack {
-                    Text(book.name)
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
-                    Spacer()
-                    Text("\(games.count)")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
+    private var hasChildren: Bool {
+        !subBooks.isEmpty || !games.isEmpty
+    }
 
-                Divider()
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                HStack(spacing: 0) {
+                    ForEach(0..<level, id: \.self) { _ in
+                        Rectangle()
+                            .fill(Color.clear)
+                            .frame(width: 16)
+                    }
+                }
+
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        toggleExpanded()
+                    }
+                }) {
+                    Image(systemName: !hasChildren ? "circle" : (isExpanded ? "chevron.down" : "chevron.right"))
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!hasChildren)
+
+                Image(systemName: "folder.fill")
+                    .foregroundColor(.blue)
+                    .font(.system(size: 12))
+
+                Text(book.name)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.vertical, 3)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    toggleExpanded()
+                }
             }
 
-            if games.isEmpty {
-                VStack {
-                    Spacer()
-                    Text(selectedBookId == nil ? "请选择棋谱" : "暂无棋局")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
+            if isExpanded {
+                ForEach(subBooks) { subBook in
+                    SidebarBookNodeView(
+                        book: subBook,
+                        viewModel: viewModel,
+                        expandedBookIds: $expandedBookIds,
+                        level: level + 1
+                    )
                 }
-                .frame(maxWidth: .infinity)
-            } else {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 1) {
-                            ForEach(games) { game in
-                                SidebarGameItemView(game: game, viewModel: viewModel)
-                                    .id(game.id)
-                            }
-                        }
-                        .padding(.horizontal, 4)
-                    }
-                    .onAppear {
-                        if let gameId = viewModel.currentSpecificGameId {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                withAnimation {
-                                    proxy.scrollTo(gameId, anchor: .center)
-                                }
-                            }
-                        }
-                    }
-                    .onChange(of: viewModel.currentSpecificGameId) {
-                        if let gameId = viewModel.currentSpecificGameId {
-                            withAnimation {
-                                proxy.scrollTo(gameId, anchor: .center)
-                            }
-                        }
-                    }
+
+                ForEach(games) { game in
+                    SidebarGameItemView(game: game, viewModel: viewModel, level: level + 1)
+                        .id(game.id)
                 }
             }
         }
@@ -1244,23 +1271,36 @@ struct SidebarGameListView: View {
 struct SidebarGameItemView: View {
     let game: GameObject
     @ObservedObject var viewModel: ViewModel
+    let level: Int
 
     private var isCurrentGame: Bool {
         viewModel.currentSpecificGameId == game.id
     }
 
     var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "doc.text")
-                .foregroundColor(.orange)
-                .font(.system(size: 11))
-            Text(game.displayTitle)
-                .font(.system(size: 12))
-                .lineLimit(1)
-            Spacer()
+        HStack(spacing: 0) {
+            ForEach(0..<level, id: \.self) { _ in
+                Rectangle()
+                    .fill(Color.clear)
+                    .frame(width: 16)
+            }
+
+            Rectangle()
+                .fill(Color.clear)
+                .frame(width: 16)
+
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .foregroundColor(.orange)
+                    .font(.system(size: 11))
+                Text(game.displayTitle)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                Spacer()
+            }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 5)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 3)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(isCurrentGame ? Color.accentColor.opacity(0.2) : Color.clear)

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1138,6 +1138,7 @@ struct GameBrowserSidebarView: View {
     @ObservedObject var viewModel: ViewModel
     @State private var expandedBookIds: Set<UUID>?
     @State private var selectedGameId: UUID?
+    @State private var cachedRows: [SidebarRow] = []
 
     private func isBookExpanded(_ bookId: UUID) -> Bool {
         guard let ids = expandedBookIds else { return true }
@@ -1169,7 +1170,7 @@ struct GameBrowserSidebarView: View {
         return allGames
     }
 
-    private var visibleRows: [SidebarRow] {
+    private func rebuildRows() {
         var rows: [SidebarRow] = []
         func walk(_ books: [BookObject], level: Int) {
             for book in books {
@@ -1188,7 +1189,7 @@ struct GameBrowserSidebarView: View {
             }
         }
         walk(viewModel.allTopLevelBookObjects, level: 0)
-        return rows
+        cachedRows = rows
     }
 
     var body: some View {
@@ -1203,7 +1204,7 @@ struct GameBrowserSidebarView: View {
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 2) {
-                    ForEach(visibleRows) { row in
+                    ForEach(cachedRows) { row in
                         switch row {
                         case .book(let book, let level, let isExpanded, let hasChildren):
                             SidebarBookRowView(
@@ -1216,7 +1217,6 @@ struct GameBrowserSidebarView: View {
                         case .game(let game, let level):
                             SidebarGameRowView(
                                 game: game,
-                                viewModel: viewModel,
                                 level: level,
                                 isSelected: selectedGameId == game.id,
                                 isCurrentGame: viewModel.currentSpecificGameId == game.id,
@@ -1236,9 +1236,14 @@ struct GameBrowserSidebarView: View {
         .background(Color.adaptiveBackground)
         .onAppear {
             expandedBookIds = viewModel.session.sessionData.gameBrowserExpandedBookIds
+            rebuildRows()
         }
         .onChange(of: expandedBookIds) {
             viewModel.session.sessionData.gameBrowserExpandedBookIds = expandedBookIds
+            rebuildRows()
+        }
+        .onReceive(viewModel.session.$dataChanged) { _ in
+            rebuildRows()
         }
     }
 }
@@ -1297,7 +1302,6 @@ private struct SidebarBookRowView: View {
 
 private struct SidebarGameRowView: View {
     let game: GameObject
-    @ObservedObject var viewModel: ViewModel
     let level: Int
     let isSelected: Bool
     let isCurrentGame: Bool

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1134,10 +1134,14 @@ private enum SidebarRow: Identifiable {
     }
 }
 
+private class SidebarSelection: ObservableObject {
+    @Published var gameId: UUID?
+}
+
 struct GameBrowserSidebarView: View {
     @ObservedObject var viewModel: ViewModel
     @State private var expandedBookIds: Set<UUID>?
-    @State private var selectedGameId: UUID?
+    @StateObject private var selection = SidebarSelection()
     @State private var cachedRows: [SidebarRow] = []
 
     private func isBookExpanded(_ bookId: UUID) -> Bool {
@@ -1273,13 +1277,8 @@ struct GameBrowserSidebarView: View {
                             SidebarGameRowView(
                                 game: game,
                                 level: level,
-                                isSelected: selectedGameId == game.id,
+                                selection: selection,
                                 isCurrentGame: viewModel.currentSpecificGameId == game.id,
-                                onSelect: {
-                                    withAnimation(.easeInOut(duration: 0.15)) {
-                                        selectedGameId = selectedGameId == game.id ? nil : game.id
-                                    }
-                                },
                                 onLoad: { viewModel.loadGame(game.id) }
                             )
                         }
@@ -1357,10 +1356,13 @@ private struct SidebarBookRowView: View {
 private struct SidebarGameRowView: View {
     let game: GameObject
     let level: Int
-    let isSelected: Bool
+    @ObservedObject var selection: SidebarSelection
     let isCurrentGame: Bool
-    let onSelect: () -> Void
     let onLoad: () -> Void
+
+    private var isSelected: Bool {
+        selection.gameId == game.id
+    }
 
     private let indentWidth: CGFloat = 16
 
@@ -1447,7 +1449,9 @@ private struct SidebarGameRowView: View {
             onLoad()
         }
         .onTapGesture {
-            onSelect()
+            withAnimation(.easeInOut(duration: 0.15)) {
+                selection.gameId = isSelected ? nil : game.id
+            }
         }
     }
 }

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1119,6 +1119,160 @@ struct GameActionSection: View {
     }
 }
 
+// MARK: - 主页面侧栏：棋局浏览器侧栏
+#if os(macOS)
+struct GameBrowserSidebarView: View {
+    @ObservedObject var viewModel: ViewModel
+    @State private var selectedBookId: UUID?
+    @State private var expandedBookIds: Set<UUID>?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            BookTreeSidebarView(
+                viewModel: viewModel,
+                selectedBookId: $selectedBookId,
+                expandedBookIds: $expandedBookIds,
+                showingPGNImportSheet: .constant(false)
+            )
+
+            Divider()
+
+            SidebarGameListView(
+                viewModel: viewModel,
+                selectedBookId: selectedBookId
+            )
+        }
+        .background(Color.adaptiveBackground)
+        .onAppear {
+            let sessionData = viewModel.session.sessionData
+            expandedBookIds = sessionData.gameBrowserExpandedBookIds
+            selectedBookId = sessionData.gameBrowserSelectedBookId
+        }
+        .onChange(of: selectedBookId) {
+            viewModel.session.sessionData.gameBrowserSelectedBookId = selectedBookId
+        }
+        .onChange(of: expandedBookIds) {
+            viewModel.session.sessionData.gameBrowserExpandedBookIds = expandedBookIds
+        }
+    }
+}
+
+struct SidebarGameListView: View {
+    @ObservedObject var viewModel: ViewModel
+    let selectedBookId: UUID?
+
+    private var selectedBook: BookObject? {
+        guard let bookId = selectedBookId else { return nil }
+        return viewModel.allBookObjects.first { $0.id == bookId }
+    }
+
+    private var games: [GameObject] {
+        guard let bookId = selectedBookId else { return [] }
+        let allGames = viewModel.getGamesInBook(bookId)
+        let hasRealGames = allGames.contains { $0.iAmRed || $0.iAmBlack }
+        if hasRealGames {
+            return allGames.sorted { g1, g2 in
+                let d1 = g1.gameDate ?? g1.creationDate ?? .distantPast
+                let d2 = g2.gameDate ?? g2.creationDate ?? .distantPast
+                return d1 > d2
+            }
+        }
+        return allGames
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let book = selectedBook {
+                HStack {
+                    Text(book.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    Spacer()
+                    Text("\(games.count)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+
+                Divider()
+            }
+
+            if games.isEmpty {
+                VStack {
+                    Spacer()
+                    Text(selectedBookId == nil ? "请选择棋谱" : "暂无棋局")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 1) {
+                            ForEach(games) { game in
+                                SidebarGameItemView(game: game, viewModel: viewModel)
+                                    .id(game.id)
+                            }
+                        }
+                        .padding(.horizontal, 4)
+                    }
+                    .onAppear {
+                        if let gameId = viewModel.currentSpecificGameId {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                withAnimation {
+                                    proxy.scrollTo(gameId, anchor: .center)
+                                }
+                            }
+                        }
+                    }
+                    .onChange(of: viewModel.currentSpecificGameId) {
+                        if let gameId = viewModel.currentSpecificGameId {
+                            withAnimation {
+                                proxy.scrollTo(gameId, anchor: .center)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SidebarGameItemView: View {
+    let game: GameObject
+    @ObservedObject var viewModel: ViewModel
+
+    private var isCurrentGame: Bool {
+        viewModel.currentSpecificGameId == game.id
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "doc.text")
+                .foregroundColor(.orange)
+                .font(.system(size: 11))
+            Text(game.displayTitle)
+                .font(.system(size: 12))
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isCurrentGame ? Color.accentColor.opacity(0.2) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            viewModel.loadGame(game.id)
+        }
+    }
+}
+#endif
+
 #Preview {
     #if os(macOS)
     GameBrowserView(viewModel: ViewModel(platformService: MacOSPlatformService()))

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1121,10 +1121,75 @@ struct GameActionSection: View {
 
 // MARK: - 主页面侧栏：棋局浏览器侧栏
 #if os(macOS)
+
+private enum SidebarRow: Identifiable {
+    case book(BookObject, level: Int, isExpanded: Bool, hasChildren: Bool)
+    case game(GameObject, level: Int)
+
+    var id: String {
+        switch self {
+        case .book(let book, _, _, _): return "b-\(book.id)"
+        case .game(let game, _): return "g-\(game.id)"
+        }
+    }
+}
+
 struct GameBrowserSidebarView: View {
     @ObservedObject var viewModel: ViewModel
     @State private var expandedBookIds: Set<UUID>?
     @State private var selectedGameId: UUID?
+
+    private func isBookExpanded(_ bookId: UUID) -> Bool {
+        guard let ids = expandedBookIds else { return true }
+        return ids.contains(bookId)
+    }
+
+    private func toggleBookExpanded(_ bookId: UUID) {
+        if expandedBookIds == nil {
+            var allIds = Set(viewModel.allBookObjects.map { $0.id })
+            allIds.remove(bookId)
+            expandedBookIds = allIds
+        } else if expandedBookIds!.contains(bookId) {
+            expandedBookIds!.remove(bookId)
+        } else {
+            expandedBookIds!.insert(bookId)
+        }
+    }
+
+    private func gamesInBook(_ bookId: UUID) -> [GameObject] {
+        let allGames = viewModel.getGamesInBook(bookId)
+        let hasRealGames = allGames.contains { $0.iAmRed || $0.iAmBlack }
+        if hasRealGames {
+            return allGames.sorted { g1, g2 in
+                let d1 = g1.gameDate ?? g1.creationDate ?? .distantPast
+                let d2 = g2.gameDate ?? g2.creationDate ?? .distantPast
+                return d1 > d2
+            }
+        }
+        return allGames
+    }
+
+    private var visibleRows: [SidebarRow] {
+        var rows: [SidebarRow] = []
+        func walk(_ books: [BookObject], level: Int) {
+            for book in books {
+                let expanded = isBookExpanded(book.id)
+                let hasChildren = !book.subBookIds.isEmpty || !book.gameIds.isEmpty
+                rows.append(.book(book, level: level, isExpanded: expanded, hasChildren: hasChildren))
+                if expanded {
+                    let subBooks = book.subBookIds.compactMap { subId in
+                        viewModel.allBookObjects.first { $0.id == subId }
+                    }
+                    walk(subBooks, level: level + 1)
+                    for game in gamesInBook(book.id) {
+                        rows.append(.game(game, level: level + 1))
+                    }
+                }
+            }
+        }
+        walk(viewModel.allTopLevelBookObjects, level: 0)
+        return rows
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -1138,14 +1203,31 @@ struct GameBrowserSidebarView: View {
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 2) {
-                    ForEach(viewModel.allTopLevelBookObjects) { book in
-                        SidebarBookNodeView(
-                            book: book,
-                            viewModel: viewModel,
-                            expandedBookIds: $expandedBookIds,
-                            selectedGameId: $selectedGameId,
-                            level: 0
-                        )
+                    ForEach(visibleRows) { row in
+                        switch row {
+                        case .book(let book, let level, let isExpanded, let hasChildren):
+                            SidebarBookRowView(
+                                book: book,
+                                level: level,
+                                isExpanded: isExpanded,
+                                hasChildren: hasChildren,
+                                onToggle: { toggleBookExpanded(book.id) }
+                            )
+                        case .game(let game, let level):
+                            SidebarGameRowView(
+                                game: game,
+                                viewModel: viewModel,
+                                level: level,
+                                isSelected: selectedGameId == game.id,
+                                isCurrentGame: viewModel.currentSpecificGameId == game.id,
+                                onSelect: {
+                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                        selectedGameId = selectedGameId == game.id ? nil : game.id
+                                    }
+                                },
+                                onLoad: { viewModel.loadGame(game.id) }
+                            )
+                        }
                     }
                 }
                 .padding(.horizontal)
@@ -1161,130 +1243,66 @@ struct GameBrowserSidebarView: View {
     }
 }
 
-struct SidebarBookNodeView: View {
+private struct SidebarBookRowView: View {
     let book: BookObject
-    @ObservedObject var viewModel: ViewModel
-    @Binding var expandedBookIds: Set<UUID>?
-    @Binding var selectedGameId: UUID?
     let level: Int
-
-    private var isExpanded: Bool {
-        guard let ids = expandedBookIds else { return true }
-        return ids.contains(book.id)
-    }
-
-    private func toggleExpanded() {
-        if expandedBookIds == nil {
-            var allIds = Set(viewModel.allBookObjects.map { $0.id })
-            allIds.remove(book.id)
-            expandedBookIds = allIds
-        } else if expandedBookIds!.contains(book.id) {
-            expandedBookIds!.remove(book.id)
-        } else {
-            expandedBookIds!.insert(book.id)
-        }
-    }
-
-    private var subBooks: [BookObject] {
-        book.subBookIds.compactMap { subBookId in
-            viewModel.allBookObjects.first { $0.id == subBookId }
-        }
-    }
-
-    private var games: [GameObject] {
-        let allGames = viewModel.getGamesInBook(book.id)
-        let hasRealGames = allGames.contains { $0.iAmRed || $0.iAmBlack }
-        if hasRealGames {
-            return allGames.sorted { g1, g2 in
-                let d1 = g1.gameDate ?? g1.creationDate ?? .distantPast
-                let d2 = g2.gameDate ?? g2.creationDate ?? .distantPast
-                return d1 > d2
-            }
-        }
-        return allGames
-    }
-
-    private var hasChildren: Bool {
-        !book.subBookIds.isEmpty || !book.gameIds.isEmpty
-    }
+    let isExpanded: Bool
+    let hasChildren: Bool
+    let onToggle: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                HStack(spacing: 0) {
-                    ForEach(0..<level, id: \.self) { _ in
-                        Rectangle()
-                            .fill(Color.clear)
-                            .frame(width: 16)
-                    }
+        HStack {
+            HStack(spacing: 0) {
+                ForEach(0..<level, id: \.self) { _ in
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: 16)
                 }
-
-                Button(action: {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        toggleExpanded()
-                    }
-                }) {
-                    Image(systemName: !hasChildren ? "circle" : (isExpanded ? "chevron.down" : "chevron.right"))
-                        .font(.system(size: 10))
-                        .foregroundColor(.secondary)
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(!hasChildren)
-
-                Image(systemName: "folder.fill")
-                    .foregroundColor(.blue)
-                    .font(.system(size: 12))
-
-                Text(book.name)
-                    .font(.system(size: 12))
-                    .lineLimit(1)
-
-                Spacer()
             }
-            .padding(.vertical, 3)
-            .padding(.horizontal, 4)
-            .contentShape(Rectangle())
-            .onTapGesture {
+
+            Button(action: {
                 withAnimation(.easeInOut(duration: 0.2)) {
-                    toggleExpanded()
+                    onToggle()
                 }
+            }) {
+                Image(systemName: !hasChildren ? "circle" : (isExpanded ? "chevron.down" : "chevron.right"))
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .disabled(!hasChildren)
 
-            if isExpanded {
-                ForEach(subBooks) { subBook in
-                    SidebarBookNodeView(
-                        book: subBook,
-                        viewModel: viewModel,
-                        expandedBookIds: $expandedBookIds,
-                        selectedGameId: $selectedGameId,
-                        level: level + 1
-                    )
-                }
+            Image(systemName: "folder.fill")
+                .foregroundColor(.blue)
+                .font(.system(size: 12))
 
-                ForEach(games) { game in
-                    SidebarGameItemView(game: game, viewModel: viewModel, level: level + 1, selectedGameId: $selectedGameId)
-                        .id(game.id)
-                }
+            Text(book.name)
+                .font(.system(size: 12))
+                .lineLimit(1)
+
+            Spacer()
+        }
+        .padding(.vertical, 3)
+        .padding(.horizontal, 4)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                onToggle()
             }
         }
     }
 }
 
-struct SidebarGameItemView: View {
+private struct SidebarGameRowView: View {
     let game: GameObject
     @ObservedObject var viewModel: ViewModel
     let level: Int
-    @Binding var selectedGameId: UUID?
-
-    private var isCurrentGame: Bool {
-        viewModel.currentSpecificGameId == game.id
-    }
-
-    private var isSelected: Bool {
-        selectedGameId == game.id
-    }
+    let isSelected: Bool
+    let isCurrentGame: Bool
+    let onSelect: () -> Void
+    let onLoad: () -> Void
 
     private let indentWidth: CGFloat = 16
 
@@ -1347,7 +1365,7 @@ struct SidebarGameItemView: View {
                             }
                         }
 
-                        Button(action: { viewModel.loadGame(game.id) }) {
+                        Button(action: onLoad) {
                             Text("加载棋局")
                                 .font(.system(size: 11))
                         }
@@ -1368,12 +1386,10 @@ struct SidebarGameItemView: View {
         )
         .contentShape(Rectangle())
         .onTapGesture(count: 2) {
-            viewModel.loadGame(game.id)
+            onLoad()
         }
         .onTapGesture {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                selectedGameId = isSelected ? nil : game.id
-            }
+            onSelect()
         }
     }
 }

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -28,9 +28,11 @@ struct MacContentView: View {
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
                     // 棋局浏览器侧栏
-                    GameBrowserSidebarView(viewModel: viewModel)
-                        .frame(width: 250)
-                    Divider()
+                    if viewModel.showGameBrowserSidebar {
+                        GameBrowserSidebarView(viewModel: viewModel)
+                            .frame(width: 250)
+                        Divider()
+                    }
 
                     // 左侧区域：棋盘
                     VStack(spacing: 0) {
@@ -311,6 +313,8 @@ struct MacMenuCommands: Commands {
 
         // 显示 menu
         CommandGroup(after: .toolbar) {
+            Divider()
+            menuToggle(.toggleGameBrowserSidebar)
             Divider()
             menuToggle(.flip)
             menuToggle(.flipHorizontal)

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -28,11 +28,9 @@ struct MacContentView: View {
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
                     // 棋局浏览器侧栏
-                    if viewModel.showGameBrowserSidebar {
-                        GameBrowserSidebarView(viewModel: viewModel)
-                            .frame(width: 250)
-                        Divider()
-                    }
+                    GameBrowserSidebarView(viewModel: viewModel)
+                        .frame(width: 250)
+                    Divider()
 
                     // 左侧区域：棋盘
                     VStack(spacing: 0) {
@@ -313,8 +311,6 @@ struct MacMenuCommands: Commands {
 
         // 显示 menu
         CommandGroup(after: .toolbar) {
-            Divider()
-            menuToggle(.toggleGameBrowserSidebar)
             Divider()
             menuToggle(.flip)
             menuToggle(.flipHorizontal)

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -27,6 +27,13 @@ struct MacContentView: View {
         GeometryReader { geometry in
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
+                    // 棋局浏览器侧栏
+                    if viewModel.showGameBrowserSidebar {
+                        GameBrowserSidebarView(viewModel: viewModel)
+                            .frame(width: 250)
+                        Divider()
+                    }
+
                     // 左侧区域：棋盘
                     VStack(spacing: 0) {
                         // 棋盘 - 设置为屏幕高度的一半
@@ -306,6 +313,8 @@ struct MacMenuCommands: Commands {
 
         // 显示 menu
         CommandGroup(after: .toolbar) {
+            Divider()
+            menuToggle(.toggleGameBrowserSidebar)
             Divider()
             menuToggle(.flip)
             menuToggle(.flipHorizontal)


### PR DESCRIPTION
## Summary
- macOS 版主页面左侧新增可收起的棋局浏览器侧栏（250pt 宽），方便快速跳转棋局
- 侧栏包含棋书树形列表和棋局列表，点击棋局直接加载，当前棋局高亮显示
- 快捷键 `,gb` 切换侧栏显示/隐藏，原棋局浏览器 sheet 快捷键改为 `,gB`
- 侧栏状态（显示/隐藏、选中棋书、展开节点）通过 SessionData 持久化

Closes #113

## Test plan
- [ ] 默认状态下侧栏不可见，界面与之前一致
- [ ] 通过显示菜单或快捷键 `,gb` 切换侧栏显示/隐藏
- [ ] 侧栏中选择棋书后显示对应棋局列表
- [ ] 点击棋局直接加载到主界面，当前棋局高亮
- [ ] `,gB` 仍可打开全功能棋局浏览器 sheet
- [ ] 关闭重开 app 后侧栏状态保持
- [ ] 全部单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)