### PR TITLE
棋局浏览器中的棋书和棋局列表按字母序排列

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -2154,7 +2154,9 @@ class ViewModel: ObservableObject {
     }
 
     var allTopLevelBookObjects: [BookObject] {
-        session.allTopLevelBookObjects
+        session.allTopLevelBookObjects.sorted { b1, b2 in
+            b1.name.localizedStandardCompare(b2.name) == .orderedAscending
+        }
     }
 
     var allBookObjects: [BookObject] {
@@ -2171,6 +2173,14 @@ class ViewModel: ObservableObject {
 
     func getGamesInBook(_ bookId: UUID) -> [GameObject] {
         session.getGamesInBook(bookId)
+    }
+
+    func getSubBooksInBook(_ book: BookObject) -> [BookObject] {
+        book.subBookIds.compactMap { id in
+            session.allBookObjects.first { $0.id == id }
+        }.sorted { b1, b2 in
+            b1.name.localizedStandardCompare(b2.name) == .orderedAscending
+        }
     }
 
     func addCurrentGameToMyRealGame(gameInfo: GameObject) -> Bool {

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -466,9 +466,7 @@ struct BookTreeNodeView: View {
     }
 
     private var subBooks: [BookObject] {
-        book.subBookIds.compactMap { subBookId in
-            viewModel.allBookObjects.first { $0.id == subBookId }
-        }
+        viewModel.getSubBooksInBook(book)
     }
 
     private var gameCount: Int {
@@ -485,9 +483,7 @@ struct BookTreeNodeView: View {
 
     private func getTotalGameCountForBook(_ book: BookObject) -> Int {
         let directGames = viewModel.getGamesInBook(book.id).count
-        let subBooks = book.subBookIds.compactMap { subBookId in
-            viewModel.allBookObjects.first { $0.id == subBookId }
-        }
+        let subBooks = viewModel.getSubBooksInBook(book)
         let subBooksGames = subBooks.reduce(0) { total, subBook in
             total + getTotalGameCountForBook(subBook)
         }
@@ -641,7 +637,9 @@ struct GameListView: View {
                 return d1 > d2
             }
         }
-        return allGames
+        return allGames.sorted { g1, g2 in
+            g1.displayTitle.localizedStandardCompare(g2.displayTitle) == .orderedAscending
+        }
     }
 
     var body: some View {
@@ -1166,7 +1164,9 @@ struct GameBrowserSidebarView: View {
                 return d1 > d2
             }
         }
-        return allGames
+        return allGames.sorted { g1, g2 in
+            g1.displayTitle.localizedStandardCompare(g2.displayTitle) == .orderedAscending
+        }
     }
 
     private var visibleRows: [SidebarRow] {
@@ -1177,9 +1177,7 @@ struct GameBrowserSidebarView: View {
                 let hasChildren = !book.subBookIds.isEmpty || !book.gameIds.isEmpty
                 rows.append(.book(book, level: level, isExpanded: expanded, hasChildren: hasChildren))
                 if expanded {
-                    let subBooks = book.subBookIds.compactMap { subId in
-                        viewModel.allBookObjects.first { $0.id == subId }
-                    }
+                    let subBooks = viewModel.getSubBooksInBook(book)
                     walk(subBooks, level: level + 1)
                     for game in gamesInBook(book.id) {
                         rows.append(.game(game, level: level + 1))


### PR DESCRIPTION
## Summary
- 顶级棋书和子棋书按名称拼音序排列（使用 `localizedStandardCompare`）
- 非实战棋局按 `displayTitle` 拼音序排列
- 实战棋局保持按日期降序排列不变
- 新增 `ViewModel.getSubBooksInBook(_:)` 方法消除子棋书查找的重复代码

Closes #121

## Test plan
- [ ] 打开棋局浏览器侧栏（`,gb`），确认棋书按拼音序排列
- [ ] 打开全屏棋局浏览器（`,gB`），确认棋书和棋局按拼音序排列
- [ ] 确认含子棋书的棋书展开后，子棋书也按拼音序排列
- [ ] 确认实战棋局仍按日期降序排列
- [ ] 全部单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)