### PR TITLE
修复引擎评估在后台线程修改数据导致的并发崩溃

### DIFF
--- a/XiangqiNotebook/Services/EvaluationQueue.swift
+++ b/XiangqiNotebook/Services/EvaluationQueue.swift
@@ -115,7 +115,9 @@ class EvaluationQueue: ObservableObject {
 
     private func startProcessingIfNeeded() {
         guard processingTask == nil else { return }
-        processingTask = Task { [weak self] in
+        // 必须在 MainActor 上处理：回调会修改 Session/Database 数据，
+        // 队列状态也与主线程的 enqueue/cancelAll 共享，否则产生数据竞争
+        processingTask = Task { @MainActor [weak self] in
             while let self = self, !Task.isCancelled {
                 guard !self.pendingRequests.isEmpty else { break }
                 await self.processNext()
@@ -135,6 +137,7 @@ class EvaluationQueue: ObservableObject {
         }
     }
 
+    @MainActor
     private func processNext() async {
         guard !pendingRequests.isEmpty else { return }
         let request = pendingRequests.removeFirst()

--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1399,11 +1399,14 @@ class ViewModel: ObservableObject {
 
         do {
             if let result = try await service.evaluatePosition(fen: fen, movetime: 3000) {
-                session.updateEngineScore(fenId, score: result.score, engineKey: PikafishService.quickEngineKey)
-                if let uciMove = result.bestMove,
-                   let newFen = XiangqiBoardUtils.getNewFenAfterUCIMove(uciMove: uciMove, fen: fen) {
-                    _ = session.playNewBoardFen(newFen)
-                    session.updateEngineScore(session.currentFenId, score: -result.score, engineKey: PikafishService.quickEngineKey)
+                // await 之后在后台线程恢复，数据修改必须回到主线程，否则与主线程读取产生数据竞争
+                await MainActor.run {
+                    session.updateEngineScore(fenId, score: result.score, engineKey: PikafishService.quickEngineKey)
+                    if let uciMove = result.bestMove,
+                       let newFen = XiangqiBoardUtils.getNewFenAfterUCIMove(uciMove: uciMove, fen: fen) {
+                        _ = session.playNewBoardFen(newFen)
+                        session.updateEngineScore(session.currentFenId, score: -result.score, engineKey: PikafishService.quickEngineKey)
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
## 概述

修复 #129：皮卡鱼引擎评估完成后在后台线程修改共享模型数据，与主线程读取 `fenObjects2` 构成数据竞争，导致 Dictionary 内部存储损坏崩溃（`-[NSIndexPath objectForKey:]` 发到 `0x8000000000000000`）。

## 根因

1. **`EvaluationQueue.startProcessingIfNeeded()`**（#126 引入）：`Task { }` 在非隔离 class 中创建，跑在全局后台执行器上。完成回调 `onEvaluationCompleted → session.updateEngineScore` 在后台线程修改数据并翻转 `@Published dataChanged`。
2. **`ViewModel.pikafishQuickMove()`**（#81 引入）：`await evaluatePosition` 之后在后台线程恢复，直接调 `session.playNewBoardFen(newFen)` 写入 `fenObjects2`，与主线程 `updateBoardView → getNextMovesPathGroups → extractPieceMove` 的字典读取并发。

## 修复

- `EvaluationQueue`：处理循环改为 `Task { @MainActor in }`，`processNext()` 标记 `@MainActor`。回调和队列状态（`pendingRequests`/`dedupSet`/`@Published state`）全部回到主线程。引擎 I/O 不受影响：`evaluatePosition` 是非隔离 async，await 期间主线程不阻塞。
- `pikafishQuickMove()`：await 之后的数据修改包进 `await MainActor.run { }`，与 `queryFenScore` 的既有写法保持一致。

读取侧的更大范围竞态（ViewModel 整体 @MainActor 化）另行跟踪：#128。

## 测试

- `xcodebuild test -only-testing:XiangqiNotebookTests`（macOS）全部通过

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)