### PR TITLE
视图层去重：复习面板 + 棋局结果配色 (#168 部分)

### DIFF
--- a/XiangqiNotebook/Models/SRSData.swift
+++ b/XiangqiNotebook/Models/SRSData.swift
@@ -57,6 +57,25 @@ class SRSData: Codable {
     }
 }
 
+extension SRSData {
+    /// 到期状态文案：已到期 / 今天到期 / 明天到期 / N 天后。
+    /// 复习库列表（Mac/iPad/iPhone）三处原本各有一份完全相同的实现，统一到此
+    var dueStatusText: String {
+        if isDue {
+            return "已到期"
+        }
+        let now = Date()
+        let days = Calendar.current.dateComponents([.day], from: now, to: nextReviewDate).day ?? 0
+        if days == 0 {
+            return "今天到期"
+        } else if days == 1 {
+            return "明天到期"
+        } else {
+            return "\(days)天后"
+        }
+    }
+}
+
 /// 复习自评等级
 enum ReviewQuality: Int, Codable {
     case again = 1

--- a/XiangqiNotebook/Views/GameResultColor.swift
+++ b/XiangqiNotebook/Views/GameResultColor.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+extension GameResult {
+    /// 棋局结果配色（深色模式友好方案）。
+    /// 原本散在 RealGameListView / iPhoneRealGameListView / GameBrowserView 四处，
+    /// 且棋谱浏览器用 .black/.orange、实战列表用 .primary/.secondary 两套不一致方案，
+    /// 统一为：黑胜 .primary（随深浅色自适应）、未完 .secondary
+    var displayColor: Color {
+        switch self {
+        case .redWin: return .red
+        case .blackWin: return .primary
+        case .draw: return .blue
+        case .notFinished: return .secondary
+        case .unknown: return .secondary
+        }
+    }
+}

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -784,8 +784,8 @@ struct GameListItemView: View {
                     .font(.system(size: 12, weight: .medium))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
-                    .background(getResultColor(game.gameResult).opacity(0.1))
-                    .foregroundColor(getResultColor(game.gameResult))
+                    .background(game.gameResult.displayColor.opacity(0.1))
+                    .foregroundColor(game.gameResult.displayColor)
                     .cornerRadius(6)
             }
         }
@@ -823,21 +823,6 @@ struct GameListItemView: View {
             }
         } message: {
             Text("确定要删除这局棋吗？此操作不可撤销。")
-        }
-    }
-    
-    private func getResultColor(_ result: GameResult) -> Color {
-        switch result {
-        case .redWin:
-            return .red
-        case .blackWin:
-            return .black
-        case .draw:
-            return .blue
-        case .notFinished:
-            return .orange
-        case .unknown:
-            return .secondary
         }
     }
 }
@@ -1027,26 +1012,11 @@ struct GameResultSection: View {
                     .font(.system(size: 16, weight: .semibold))
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
-                    .background(getResultColor(game.gameResult).opacity(0.1))
-                    .foregroundColor(getResultColor(game.gameResult))
+                    .background(game.gameResult.displayColor.opacity(0.1))
+                    .foregroundColor(game.gameResult.displayColor)
                     .cornerRadius(8)
                 Spacer()
             }
-        }
-    }
-    
-    private func getResultColor(_ result: GameResult) -> Color {
-        switch result {
-        case .redWin:
-            return .red
-        case .blackWin:
-            return .black
-        case .draw:
-            return .blue
-        case .notFinished:
-            return .orange
-        case .unknown:
-            return .secondary
         }
     }
 }

--- a/XiangqiNotebook/Views/RealGameListView.swift
+++ b/XiangqiNotebook/Views/RealGameListView.swift
@@ -68,7 +68,7 @@ private struct RealGameListItemView: View {
                     .monospacedDigit()
             }
             Text(game.gameResult.rawValue)
-                .foregroundColor(resultColor(game.gameResult))
+                .foregroundColor(game.gameResult.displayColor)
         }
         .padding(.vertical, 2)
         .padding(.horizontal, 4)
@@ -81,15 +81,6 @@ private struct RealGameListItemView: View {
             } label: {
                 Label("筛选此棋局", systemImage: "line.3.horizontal.decrease.circle")
             }
-        }
-    }
-
-    private func resultColor(_ result: GameResult) -> Color {
-        switch result {
-        case .redWin: return .red
-        case .blackWin: return .primary
-        case .draw: return .blue
-        case .notFinished, .unknown: return .secondary
         }
     }
 }

--- a/XiangqiNotebook/Views/ReviewListView.swift
+++ b/XiangqiNotebook/Views/ReviewListView.swift
@@ -39,7 +39,7 @@ struct ReviewListView: View {
                                 Text(viewModel.reviewItemDescription(fenId: item.fenId))
                                     .lineLimit(1)
                                 HStack(spacing: 8) {
-                                    Text(dueStatusText(item.srsData))
+                                    Text(item.srsData.dueStatusText)
                                         .font(.caption)
                                         .foregroundColor(item.srsData.isDue ? .red : .secondary)
                                     Text("已复习 \(item.srsData.repetitions) 次")
@@ -114,21 +114,6 @@ struct ReviewListView: View {
             Button("取消", role: .cancel) {
                 renamingFenId = nil
             }
-        }
-    }
-
-    private func dueStatusText(_ srsData: SRSData) -> String {
-        if srsData.isDue {
-            return "已到期"
-        }
-        let now = Date()
-        let days = Calendar.current.dateComponents([.day], from: now, to: srsData.nextReviewDate).day ?? 0
-        if days == 0 {
-            return "今天到期"
-        } else if days == 1 {
-            return "明天到期"
-        } else {
-            return "\(days)天后"
         }
     }
 }

--- a/XiangqiNotebook/Views/ReviewModeView.swift
+++ b/XiangqiNotebook/Views/ReviewModeView.swift
@@ -46,12 +46,7 @@ struct ReviewModeView: View {
                 .foregroundColor(.secondary)
 
             // 自评按钮
-            HStack(spacing: 6) {
-                reviewButton("忘了", quality: .again, color: .red)
-                reviewButton("困难", quality: .hard, color: .orange)
-                reviewButton("良好", quality: .good, color: .blue)
-                reviewButton("简单", quality: .easy, color: .green)
-            }
+            ReviewRatingButtons(viewModel: viewModel, spacing: 6)
 
             // 跳过按钮
             Button("跳过") {
@@ -96,15 +91,6 @@ struct ReviewModeView: View {
         }
     }
 
-    // MARK: - Helper
-
-    private func reviewButton(_ title: String, quality: ReviewQuality, color: Color) -> some View {
-        Button(title) {
-            viewModel.submitReviewRating(quality)
-        }
-        .foregroundColor(color)
-        .buttonStyle(.bordered)
-    }
 }
 
 #Preview {

--- a/XiangqiNotebook/Views/ReviewQualityButtons.swift
+++ b/XiangqiNotebook/Views/ReviewQualityButtons.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+extension ReviewQuality {
+    /// 自评按钮文案
+    var displayLabel: String {
+        switch self {
+        case .again: return "忘了"
+        case .hard: return "困难"
+        case .good: return "良好"
+        case .easy: return "简单"
+        }
+    }
+
+    /// 自评按钮配色
+    var displayColor: Color {
+        switch self {
+        case .again: return .red
+        case .hard: return .orange
+        case .good: return .blue
+        case .easy: return .green
+        }
+    }
+}
+
+/// 复习自评按钮组（忘了/困难/良好/简单）。
+/// Mac/iPad 的 ReviewModeView 与 iPhone 的 iPhoneReviewModeView 原本各有一份
+/// 完全相同的按钮 + reviewButton helper，统一到此（spacing 由调用方指定）
+struct ReviewRatingButtons: View {
+    @ObservedObject var viewModel: ViewModel
+    var spacing: CGFloat = 8
+
+    private let qualities: [ReviewQuality] = [.again, .hard, .good, .easy]
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            ForEach(qualities, id: \.self) { quality in
+                Button(quality.displayLabel) {
+                    viewModel.submitReviewRating(quality)
+                }
+                .foregroundColor(quality.displayColor)
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+}

--- a/XiangqiNotebook/Views/iOS/iPhoneRealGameListView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneRealGameListView.swift
@@ -40,7 +40,7 @@ struct iPhoneRealGameListView: View {
                                             Spacer()
                                             Text(game.gameResult.rawValue)
                                                 .font(.caption)
-                                                .foregroundColor(resultColor(game.gameResult))
+                                                .foregroundColor(game.gameResult.displayColor)
                                         }
                                     }
                                     Spacer()
@@ -87,15 +87,6 @@ struct iPhoneRealGameListView: View {
     private func isCurrentlyLoaded(_ game: GameObject) -> Bool {
         viewModel.currentFilters.contains(Session.filterSpecificGame) &&
             viewModel.currentSpecificGameId == game.id
-    }
-
-    private func resultColor(_ result: GameResult) -> Color {
-        switch result {
-        case .redWin: return .red
-        case .blackWin: return .primary
-        case .draw: return .blue
-        case .notFinished, .unknown: return .secondary
-        }
     }
 }
 

--- a/XiangqiNotebook/Views/iOS/iPhoneReviewListView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneReviewListView.swift
@@ -26,7 +26,7 @@ struct iPhoneReviewListView: View {
                                         Text(viewModel.reviewItemDescription(fenId: item.fenId))
                                             .lineLimit(1)
                                         HStack(spacing: 8) {
-                                            Text(dueStatusText(item.srsData))
+                                            Text(item.srsData.dueStatusText)
                                                 .font(.caption)
                                                 .foregroundColor(item.srsData.isDue ? .red : .secondary)
                                             Text("已复习 \(item.srsData.repetitions) 次")
@@ -115,21 +115,6 @@ struct iPhoneReviewListView: View {
         .onAppear { selectedFenId = viewModel.lockedFenId ?? viewModel.reviewItemList.first?.fenId }
         .onChange(of: viewModel.lockedFenId) { _, newValue in
             if let newValue { selectedFenId = newValue }
-        }
-    }
-
-    private func dueStatusText(_ srsData: SRSData) -> String {
-        if srsData.isDue {
-            return "已到期"
-        }
-        let now = Date()
-        let days = Calendar.current.dateComponents([.day], from: now, to: srsData.nextReviewDate).day ?? 0
-        if days == 0 {
-            return "今天到期"
-        } else if days == 1 {
-            return "明天到期"
-        } else {
-            return "\(days)天后"
         }
     }
 }

--- a/XiangqiNotebook/Views/iOS/iPhoneReviewModeView.swift
+++ b/XiangqiNotebook/Views/iOS/iPhoneReviewModeView.swift
@@ -49,7 +49,7 @@ struct iPhoneReviewModeView: View {
                                         Text(viewModel.reviewItemDescription(fenId: item.fenId))
                                             .lineLimit(1)
                                         HStack(spacing: 8) {
-                                            Text(dueStatusText(item.srsData))
+                                            Text(item.srsData.dueStatusText)
                                                 .font(.caption)
                                                 .foregroundColor(item.srsData.isDue ? .red : .secondary)
                                             Text("已复习 \(item.srsData.repetitions) 次")
@@ -126,13 +126,8 @@ struct iPhoneReviewModeView: View {
                 .padding(.horizontal)
 
             // 自评按钮
-            HStack(spacing: 8) {
-                reviewButton("忘了", quality: .again, color: .red)
-                reviewButton("困难", quality: .hard, color: .orange)
-                reviewButton("良好", quality: .good, color: .blue)
-                reviewButton("简单", quality: .easy, color: .green)
-            }
-            .padding(.horizontal)
+            ReviewRatingButtons(viewModel: viewModel, spacing: 8)
+                .padding(.horizontal)
 
             Button("跳过") {
                 viewModel.skipCurrentReviewItem()
@@ -171,30 +166,6 @@ struct iPhoneReviewModeView: View {
         }
     }
 
-    // MARK: - Helper
-
-    private func reviewButton(_ title: String, quality: ReviewQuality, color: Color) -> some View {
-        Button(title) {
-            viewModel.submitReviewRating(quality)
-        }
-        .foregroundColor(color)
-        .buttonStyle(.bordered)
-    }
-
-    private func dueStatusText(_ srsData: SRSData) -> String {
-        if srsData.isDue {
-            return "已到期"
-        }
-        let now = Date()
-        let days = Calendar.current.dateComponents([.day], from: now, to: srsData.nextReviewDate).day ?? 0
-        if days == 0 {
-            return "今天到期"
-        } else if days == 1 {
-            return "明天到期"
-        } else {
-            return "\(days)天后"
-        }
-    }
 }
 
 #Preview {


### PR DESCRIPTION
## 概述

#168 的安全子集：纯机械提取重复代码 + 统一两套不一致的结果配色。不含高风险项（三套表单合并、GameBrowserView 拆分），那些保留在 issue。

## 改动

| 重复点 | 处理 |
|---|---|
| `dueStatusText`（复习库到期文案）3 处完全相同 | 统一到 `SRSData.dueStatusText` 计算属性 |
| 自评按钮（忘了/困难/良好/简单）+ `reviewButton` helper 2 处重复 | 提取共享组件 `ReviewRatingButtons` + `ReviewQuality.displayLabel/displayColor` |
| 棋局结果→颜色映射 4 处、**两套不一致方案** | 统一到 `GameResult.displayColor`（深色模式友好版） |

## 唯一的视觉变化

结果配色原本：实战列表用 `.primary`/`.secondary`，棋谱浏览器用 `.black`/`.orange`。统一为深色模式友好方案后，**棋谱浏览器**的两个标签变化：
- 黑胜：`.black`（纯黑，深色模式下看不清）→ `.primary`（随深浅色自适应）
- 未完：`.orange` → `.secondary`（灰）

其余（红胜/和棋/不知）不变，实战列表完全不变。

## 测试

- macOS 全量单元测试通过
- iOS Simulator 构建通过
- dueStatusText / 自评按钮 / 红胜·和棋·不知 配色：零行为变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)