### PR TITLE
皮卡鱼快估本局只看快估分，不再因深评存在而跳过

### DIFF
--- a/XiangqiNotebook/ViewModels/ViewModel.swift
+++ b/XiangqiNotebook/ViewModels/ViewModel.swift
@@ -1676,8 +1676,9 @@ class ViewModel: ObservableObject {
         let game = session.sessionData.currentGame2
         var requests: [EvaluationRequest] = []
         for fenId in game {
-            if Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.quickEngineKey) != nil ||
-               Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.engineKey) != nil { continue }
+            // 只看快估分：与深评本局对称，各管各的 engineKey。
+            // 即使已有深评分，也仍补算快估分（按用户需求，不再因深评存在而跳过）
+            if Database.shared.getEngineScore(fenId: fenId, engineKey: PikafishService.quickEngineKey) != nil { continue }
             guard let fen = session.getFenForId(fenId) else { continue }
             requests.append(EvaluationRequest(fenId: fenId, fen: fen, engineKey: PikafishService.quickEngineKey, movetime: 3000))
         }


### PR DESCRIPTION
## 问题

点「皮卡鱼快估本局」(`,qa`) 对一局已经跑过「深评本局」的棋局没有任何反应。

## 原因

`quickAllEngineScores` 原本跳过「已有**快估分或深评分**」的局面。整局深评过之后，每个局面都有深评分，于是快估本局把全部局面都跳过 → 入队 0 个 → 引擎不动 → 看起来像坏了。（实测触发后 pikafish 进程 CPU 全程 0%，证实入队为空。）

## 改动

快估本局改为**只看快估分**，与深评本局对称（各只检查自己的 engineKey）：已有深评分的局面也会补算快估分。这样快估列就能被填满。

```diff
-if 有快估分 || 有深评分 { continue }
+if 有快估分 { continue }
```

## 测试

macOS 构建通过。该函数依赖 Database 单例 + 引擎，无既有单元测试覆盖，本次为一行逻辑简化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)