### PR TITLE
RemoteControlServer 增加随机 token 鉴权防 CSRF (#169 部分)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,23 +170,28 @@ xcodebuild test -project XiangqiNotebook.xcodeproj -scheme XiangqiNotebook -dest
 
 DEBUG 构建下，app 启动后会自动在 `localhost:9214` 启动远程操控 HTTP 服务器（`RemoteControlServer`），提供截图、状态查询和操作执行接口。
 
+**鉴权（防 CSRF）**：每次启动生成随机 token，所有请求必须带 `X-RemoteControl-Token` 头。token 写在 `~/Library/Application Support/XiangqiNotebook/remote-control-token.txt`，本地工具读取它来构造请求头（本机浏览器里的恶意网页读不到本地文件，因此无法伪造请求）。
+
 ### API 接口
 
 ```bash
+# 先读取本次启动的 token
+TOKEN=$(cat ~/Library/Application\ Support/XiangqiNotebook/remote-control-token.txt)
+
 # 截图当前窗口（返回 PNG）
-curl http://localhost:9214/screenshot -o /tmp/screenshot.png
+curl -H "X-RemoteControl-Token: $TOKEN" http://localhost:9214/screenshot -o /tmp/screenshot.png
 
 # 获取当前应用状态（返回 JSON）
-curl http://localhost:9214/state
+curl -H "X-RemoteControl-Token: $TOKEN" http://localhost:9214/state
 
 # 执行操作（action 名称对应 ActionDefinitions.ActionKey）
-curl -X POST http://localhost:9214/action -d '{"action":"stepForward"}'
+curl -H "X-RemoteControl-Token: $TOKEN" -X POST http://localhost:9214/action -d '{"action":"stepForward"}'
 
 # Toggle 操作可指定目标值
-curl -X POST http://localhost:9214/action -d '{"action":"toggleShowPath","value":true}'
+curl -H "X-RemoteControl-Token: $TOKEN" -X POST http://localhost:9214/action -d '{"action":"toggleShowPath","value":true}'
 
 # 列出所有可用操作
-curl http://localhost:9214/actions
+curl -H "X-RemoteControl-Token: $TOKEN" http://localhost:9214/actions
 ```
 
 ### UI 变更验证流程
@@ -194,10 +199,11 @@ curl http://localhost:9214/actions
 修改 View 层或 ViewModel 层代码后，除了运行单元测试，还应通过远程操控接口进行视觉验证：
 
 1. 构建并运行 app（DEBUG 配置）
-2. 用 `curl http://localhost:9214/screenshot -o $TMPDIR/screenshot.png` 获取截图
-3. 读取截图文件进行视觉检查（Claude 支持多模态图片理解）
-4. 用 `curl http://localhost:9214/state` 验证状态数据是否符合预期
-5. 需要时用 `/action` 接口触发操作后再截图对比
+2. 读取 token：`TOKEN=$(cat ~/Library/Application\ Support/XiangqiNotebook/remote-control-token.txt)`
+3. 用 `curl -H "X-RemoteControl-Token: $TOKEN" http://localhost:9214/screenshot -o $TMPDIR/screenshot.png` 获取截图
+4. 读取截图文件进行视觉检查（Claude 支持多模态图片理解）
+5. 用 `curl -H "X-RemoteControl-Token: $TOKEN" http://localhost:9214/state` 验证状态数据是否符合预期
+6. 需要时用 `/action` 接口触发操作后再截图对比
 
 这是对单元测试的补充，不替代测试。
 

--- a/XiangqiNotebook/Models/RemoteControlServer.swift
+++ b/XiangqiNotebook/Models/RemoteControlServer.swift
@@ -3,13 +3,71 @@
 import Foundation
 import Network
 import AppKit
+import Security
 
 class RemoteControlServer {
     private var listener: NWListener?
     private let port: UInt16 = 9214
     private let queue = DispatchQueue(label: "RemoteControlServer")
 
+    /// 每次启动生成的随机鉴权 token。
+    /// acceptLocalOnly 只挡局域网，挡不住本机浏览器里的恶意网页向 localhost 发请求；
+    /// 要求每个请求携带自定义头 X-RemoteControl-Token 才能防 CSRF：
+    /// 1) 网页跨域无法读到 token（写在本地文件/控制台）；
+    /// 2) 自定义头会触发 CORS 预检，本服务不返回 CORS 头，浏览器据此直接拦截请求。
+    let authToken: String = RemoteControlServer.generateToken()
+
+    /// HTTP 头名（小写比较）
+    static let tokenHeaderName = "x-remotecontrol-token"
+
     weak var viewModel: ViewModel?
+
+    private static func generateToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) != errSecSuccess {
+            // 退化兜底：拼接 UUID（DEBUG 工具，极端情况下可接受）
+            return (UUID().uuidString + UUID().uuidString).replacingOccurrences(of: "-", with: "").lowercased()
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// token 文件路径：本地工具读它来构造请求头；远程网页读不到本地文件
+    static func tokenFileURL() -> URL? {
+        guard let dir = try? FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true
+        ).appendingPathComponent("XiangqiNotebook") else { return nil }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("remote-control-token.txt")
+    }
+
+    private func writeTokenFile() {
+        guard let url = Self.tokenFileURL() else { return }
+        do {
+            try authToken.write(to: url, atomically: true, encoding: .utf8)
+            print("[RemoteControlServer] 鉴权 token 已写入 \(url.path)")
+        } catch {
+            print("[RemoteControlServer] token 文件写入失败：\(error)")
+        }
+    }
+
+    /// 从原始 HTTP 请求文本中提取 X-RemoteControl-Token 头的值（纯函数，便于单测）
+    static func extractToken(from requestString: String) -> String? {
+        // 只在头部（首个空行之前）查找，避免 body 里的同名串被误读
+        let head: Substring
+        if let headerEnd = requestString.range(of: "\r\n\r\n") {
+            head = requestString[requestString.startIndex..<headerEnd.lowerBound]
+        } else {
+            head = Substring(requestString)
+        }
+        for rawLine in head.split(separator: "\r\n", omittingEmptySubsequences: true) {
+            guard let colon = rawLine.firstIndex(of: ":") else { continue }
+            let name = rawLine[rawLine.startIndex..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            if name == tokenHeaderName {
+                return rawLine[rawLine.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            }
+        }
+        return nil
+    }
 
     func start() throws {
         let params = NWParameters.tcp
@@ -27,6 +85,7 @@ class RemoteControlServer {
             }
         }
 
+        writeTokenFile()
         listener?.start(queue: queue)
     }
 
@@ -97,6 +156,13 @@ class RemoteControlServer {
 
         let method = String(parts[0])
         let path = String(parts[1])
+
+        // 鉴权：所有端点都要求正确的 token，防本机浏览器 CSRF
+        guard Self.extractToken(from: str) == authToken else {
+            sendJSONResponse(connection: connection, status: "403 Forbidden",
+                             body: #"{"error":"Missing or invalid X-RemoteControl-Token header"}"#)
+            return
+        }
 
         var body = ""
         if let headerEnd = str.range(of: "\r\n\r\n") {

--- a/XiangqiNotebookTests/RemoteControlServerTests.swift
+++ b/XiangqiNotebookTests/RemoteControlServerTests.swift
@@ -1,0 +1,52 @@
+#if os(macOS)
+import Testing
+import Foundation
+@testable import XiangqiNotebook
+
+/// RemoteControlServer 鉴权相关测试（issue #169）。
+/// 仅 macOS + DEBUG 下编译，与服务本身一致。
+struct RemoteControlServerTests {
+
+    private func request(headers: [String], body: String = "") -> String {
+        let head = (["POST /action HTTP/1.1"] + headers).joined(separator: "\r\n")
+        return head + "\r\n\r\n" + body
+    }
+
+    @Test func testExtractToken_PresentAndTrimmed() {
+        let req = request(headers: [
+            "Host: localhost:9214",
+            "X-RemoteControl-Token:  abc123  ",
+            "Content-Length: 0"
+        ])
+        #expect(RemoteControlServer.extractToken(from: req) == "abc123")
+    }
+
+    @Test func testExtractToken_CaseInsensitiveHeaderName() {
+        let req = request(headers: ["x-remotecontrol-token: deadbeef"])
+        #expect(RemoteControlServer.extractToken(from: req) == "deadbeef")
+    }
+
+    @Test func testExtractToken_Missing_ReturnsNil() {
+        let req = request(headers: ["Host: localhost:9214", "Content-Length: 0"])
+        #expect(RemoteControlServer.extractToken(from: req) == nil)
+    }
+
+    @Test func testExtractToken_IgnoresBodyOccurrence() {
+        // body 里出现同名串不应被当作头
+        let req = request(headers: ["Host: localhost"], body: "X-RemoteControl-Token: fake")
+        #expect(RemoteControlServer.extractToken(from: req) == nil)
+    }
+
+    @Test func testAuthToken_Is64HexChars() {
+        let server = RemoteControlServer()
+        #expect(server.authToken.count == 64)
+        #expect(server.authToken.allSatisfy { $0.isHexDigit })
+    }
+
+    @Test func testAuthToken_DifferentPerInstance() {
+        let a = RemoteControlServer()
+        let b = RemoteControlServer()
+        #expect(a.authToken != b.authToken)
+    }
+}
+#endif


### PR DESCRIPTION
## 问题

DEBUG 构建的远程操控服务（`localhost:9214`）原本**零验证**。`acceptLocalOnly` 只挡局域网，挡不住你浏览器里打开的恶意网页向 localhost 发请求——它能 POST `/action` 触发有副作用的操作（删着法等）。这是一个真实的 CSRF 缺口（仅 DEBUG 构建）。

## 改动

- 启动时生成 32 字节随机 token；**所有端点**都要求请求带 `X-RemoteControl-Token` 头，否则 403。
- token 写入 `~/Library/Application Support/XiangqiNotebook/remote-control-token.txt`，本地工具读它构造请求头。
- 双重防护：① 远程网页读不到本地文件，拿不到 token；② 自定义头会触发 CORS 预检，本服务不返回 CORS 头 → 浏览器直接拦截跨域请求。
- `extractToken` 做成纯函数，加 6 个单元测试（大小写不敏感、去空白、缺失返回 nil、不误读 body、token 为 64 位 hex、实例间不同）。
- `CLAUDE.md` 远程操控文档同步更新（curl 示例改为先读 token 再带头）。

## 测试

macOS 全量单元测试通过（含新增 RemoteControlServerTests 6 项）。改动全在 `#if DEBUG && os(macOS)` 内，iOS/Release 不受影响。

## 备注

#169 的另一半「修复 UITests target」未做——那是独立的构建配置问题，保留在 issue 里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)