### PR TITLE
修复 UITests target：补回源文件使其可加载可运行 (#169 部分)

### DIFF
--- a/XiangqiNotebookUITests/XiangqiNotebookUITests.swift
+++ b/XiangqiNotebookUITests/XiangqiNotebookUITests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+/// UITests target 的烟雾测试。
+///
+/// 背景（issue #169）：此前 UITests target 内没有任何源文件，导致测试 bundle
+/// 编译不出可执行文件，运行时报「未能找到其可执行文件的位置」而整体失败。
+/// 这里提供一个最小的启动测试，既给 bundle 提供可执行文件、修复加载错误，
+/// 也对「app 能正常启动到前台」做基本验证。
+final class XiangqiNotebookUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    /// 注意：UI 测试会接管 app 生命周期，运行时不应有同一 app 的其它实例在跑
+    /// （否则 XCUIApplication.launch() 会因无法终止外部实例而失败）。
+    @MainActor
+    func testAppLaunchesToForeground() throws {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 15),
+            "app 应在 15 秒内启动到前台"
+        )
+    }
+}


### PR DESCRIPTION
## 问题

UITests target（`XiangqiNotebookUITests`）内**没有任何源文件**，测试 bundle 编译不出可执行文件，运行时报：

> Failed to load the test bundle. … 未能找到其可执行文件的位置

导致跑 `xcodebuild test`（不加 `-only-testing` 排除）时整体失败。

## 修复

target 使用 Xcode 文件系统同步组（`PBXFileSystemSynchronizedRootGroup`, path=`XiangqiNotebookUITests`），会自动纳入该目录下所有文件。因此只需在 `XiangqiNotebookUITests/` 补一个最小的启动冒烟测试，即被自动纳入，**无需手改 pbxproj**。

冒烟测试 `testAppLaunchesToForeground`：启动 app、断言 15 秒内到达前台。既给 bundle 提供了可执行文件（修复加载错误），也对 app 能正常启动做了基本验证。

## 测试

干净环境下（无同一 app 实例在跑）**TEST SUCCEEDED**，3.2 秒通过。

> ⚠️ 注意：UI 测试会接管 app 生命周期，运行时本机不能有同一 app 的其它实例在跑（如 Xcode 调试中的实例），否则 `XCUIApplication.launch()` 会因无法终止外部实例而失败。这是 UI 测试的固有约束，已在测试文件注释中说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)