### PR TITLE
Mac 主界面视觉改版：集中设计 tokens、统一字体与控件样式

### DIFF
--- a/XiangqiNotebook/Views/BookmarkListView.swift
+++ b/XiangqiNotebook/Views/BookmarkListView.swift
@@ -5,28 +5,38 @@ struct BookmarkListView: View {
     @ObservedObject var viewModel: ViewModel
     
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("书签")
+        VStack(alignment: .leading, spacing: 6) {
+            GroupHeader("书签")
+                .padding(.horizontal, 2)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(viewModel.bookmarkList, id: \.game) { bookmark in
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(viewModel.bookmarkList.enumerated()), id: \.element.game) { index, bookmark in
+                    HStack(spacing: 8) {
+                        Image(systemName: "bookmark.fill")
+                            .font(.system(size: Theme.fs(11)))
+                            .foregroundColor(Color(hex: 0xE0A93B))
                         Text(bookmark.name)
-                            .padding(.vertical, 2)
-                            .padding(.horizontal, 4)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(viewModel.isBookmarkInCurrentGame(bookmark.game) ? Color.blue.opacity(0.2) : Color.clear)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                viewModel.loadBookmark(bookmark.game)
-                            }
-                        Divider()
+                            .font(.system(size: Theme.fs(12.5)))
+                            .foregroundColor(Theme.monoText)
+                            .lineLimit(1)
+                        Spacer()
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 11)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(viewModel.isBookmarkInCurrentGame(bookmark.game) ? Theme.accent.opacity(0.12) : Color.clear)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        viewModel.loadBookmark(bookmark.game)
+                    }
+                    if index < viewModel.bookmarkList.count - 1 {
+                        Divider().overlay(Theme.hairline)
                     }
                 }
             }
+            .sectionCard()
         }
         .padding(8)
-        .border(Color.gray)
     }
 }
 

--- a/XiangqiNotebook/Views/CommentView.swift
+++ b/XiangqiNotebook/Views/CommentView.swift
@@ -4,94 +4,116 @@ import SwiftUI
 struct CommentView: View {
     @ObservedObject var viewModel: ViewModel
 
-    var body: some View {
-        HStack() {
-            // 第一列：局面评论区
-            VStack() {
-                Text("局面评论区")
-                if viewModel.isCommentEditing {
-                    TextEditor(text: .init(
-                        get: { viewModel.currentFenComment ?? "" },
-                        set: { newValue in
-                            viewModel.updateCurrentFenComment(newValue)
-                        }
-                    ))
-                    .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
-                } else {
-                    Text(viewModel.currentFenComment ?? "")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                        .background(Color.gray.opacity(0.1))
-                        .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
-                }
+    /// 评论文本块：编辑态用 TextEditor，浏览态用只读文本；统一浅底内嵌框。
+    @ViewBuilder
+    private func commentBox(text: String, isEditing: Bool, disabled: Bool = false, onChange: @escaping (String) -> Void) -> some View {
+        Group {
+            if isEditing {
+                TextEditor(text: .init(get: { text }, set: onChange))
+                    .font(.system(size: Theme.fs(12.5)))
+                    .scrollContentBackground(.hidden)
+                    .disabled(disabled)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
+            } else {
+                Text(text)
+                    .font(.system(size: Theme.fs(12.5)))
+                    .foregroundColor(Theme.monoText)
+                    .lineSpacing(2)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .insetBox()
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // 第一列：局面评论区
+            VStack(alignment: .leading, spacing: 5) {
+                GroupHeader("局面评论区")
+                commentBox(
+                    text: viewModel.currentFenComment ?? "",
+                    isEditing: viewModel.isCommentEditing,
+                    onChange: { viewModel.updateCurrentFenComment($0) }
+                )
+            }
+            .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
 
             // 第二列：招法评论区
-            VStack() {
-                Text("招法评论区")
-                if viewModel.isCommentEditing {
-                    TextEditor(text: .init(
-                        get: { viewModel.currentMoveComment ?? "" },
-                        set: { newValue in
-                            viewModel.updateCurrentMoveComment(newValue)
-                        }
-                    ))
-                    .disabled(!viewModel.hasCurrentMove)
-                    .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
-                } else {
-                    Text(viewModel.currentMoveComment ?? "")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                        .background(Color.gray.opacity(0.1))
-                        .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
-                }
+            VStack(alignment: .leading, spacing: 5) {
+                GroupHeader("招法评论区")
+                commentBox(
+                    text: viewModel.currentMoveComment ?? "",
+                    isEditing: viewModel.isCommentEditing,
+                    disabled: !viewModel.hasCurrentMove,
+                    onChange: { viewModel.updateCurrentMoveComment($0) }
+                )
             }
+            .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
 
             // 第三列：相关课程 + 不好的原因
-            VStack(spacing: 0) {
+            VStack(spacing: 7) {
                 // 上半部分：相关课程
-                VStack(alignment: .leading, spacing: 0) {
-                    Text("相关课程")
+                VStack(alignment: .leading, spacing: 5) {
+                    GroupHeader("相关课程")
                     ScrollView {
                         FlowLayout(items: viewModel.relatedCoursesForCurrentFen) { game in
                             Text(game.name ?? "未命名游戏")
+                                .font(.system(size: Theme.fs(11)))
+                                .foregroundColor(Theme.variant)
                                 .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(Color.gray.opacity(0.1))
-                                .cornerRadius(4)
+                                .padding(.vertical, 3)
+                                .background(Color(hex: 0xE7EEFC))
+                                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.row))
                                 #if os(macOS)
                                 .contextMenu {
                                     CourseVideoContextMenu(viewModel: viewModel, gameId: game.id, currentFenId: viewModel.currentFenId)
                                 }
                                 #endif
                         }
-                        .padding(.top, 8)
+                        .padding(8)
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .insetBox()
                 }
                 .frame(maxHeight: .infinity)
                 .opacity(viewModel.currentAppMode == .practice ? 0 : 1)
 
-                // 下半部分：不好的原因
+                // 下半部分：不好的原因（劣手时显示，红色框）
                 if viewModel.currentAppMode != .practice && viewModel.isCurrentMoveBad {
-                    VStack() {
-                        Text("不好的原因")
-                        if viewModel.isCommentEditing {
-                            TextEditor(text: .init(
-                                get: { viewModel.currentMoveBadReason ?? "" },
-                                set: { newValue in
-                                    viewModel.updateCurrentMoveBadReason(newValue)
-                                }
-                            ))
-                        } else {
-                            Text(viewModel.currentMoveBadReason ?? "")
-                                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                                .background(Color.gray.opacity(0.1))
+                    VStack(alignment: .leading, spacing: 5) {
+                        GroupHeader("不好的原因", color: Theme.bad)
+                        Group {
+                            if viewModel.isCommentEditing {
+                                TextEditor(text: .init(
+                                    get: { viewModel.currentMoveBadReason ?? "" },
+                                    set: { viewModel.updateCurrentMoveBadReason($0) }
+                                ))
+                                .font(.system(size: Theme.fs(12.5)))
+                                .scrollContentBackground(.hidden)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 4)
+                            } else {
+                                Text(viewModel.currentMoveBadReason ?? "")
+                                    .font(.system(size: Theme.fs(12.5)))
+                                    .foregroundColor(Theme.monoText)
+                                    .lineSpacing(2)
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 8)
+                            }
                         }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .insetBox(background: Theme.reasonBackground, border: Theme.reasonBorder)
                     }
                     .frame(maxHeight: .infinity)
                 }
             }
         }
-        .padding()
-        .border(Color.gray)
+        .padding(12)
     }
 }
 

--- a/XiangqiNotebook/Views/DesignTokens.swift
+++ b/XiangqiNotebook/Views/DesignTokens.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/// macOS 主界面视觉改版的设计令牌（颜色 / 圆角）。
+///
+/// 取值来自设计稿 `design_handoff_mac_redesign`，为最终值，跨平台共享。
+/// 仅承载“视觉细节”，不参与布局结构与棋盘渲染。
+enum Theme {
+    // MARK: - 文字
+    /// 正文主色
+    static let textPrimary = Color(hex: 0x1D1D1F)
+    /// 次要文字
+    static let textSecondary = Color(hex: 0x86868B)
+    /// 分组小标题（大写灰）
+    static let groupHeader = Color(hex: 0x9B9BA1)
+    /// 占位 / 弱文字
+    static let placeholder = Color(hex: 0xB0B0B6)
+    /// 等宽信息（FEN / UCCI 等）文字色
+    static let monoText = Color(hex: 0x3C3C43)
+
+    // MARK: - 强调
+    /// 主强调色（选中 / 复选开 / 当前着 / 主按钮）
+    static let accent = Color(hex: 0x0A84FF)
+    /// 当前变招蓝
+    static let variant = Color(hex: 0x2A6FDB)
+
+    // MARK: - 底色
+    /// 侧栏 / 右栏底色
+    static let sidebarBackground = Color(hex: 0xF4F4F7)
+    /// 中间栏底色
+    static let centerBackground = Color(hex: 0xFBFBFC)
+    /// 卡片底色
+    static let cardBackground = Color(hex: 0xFFFFFF)
+    /// 内嵌框底色
+    static let insetBackground = Color(hex: 0xF7F7F8)
+    /// 状态卡底色
+    static let statusCardBackground = Color(hex: 0xFAFAFA)
+
+    // MARK: - 评分 / 战绩
+    /// 好棋 / 分数正
+    static let good = Color(hex: 0x248A3D)
+    /// 坏棋 / 分数负
+    static let bad = Color(hex: 0xD7263D)
+    /// 已保存指示点
+    static let savedDot = Color(hex: 0x34C759)
+
+    // MARK: - 不好的原因框
+    static let reasonBorder = Color(hex: 0xD7263D, alpha: 0.3)
+    static let reasonBackground = Color(hex: 0xFDF2F3)
+
+    // MARK: - 分隔线 / 边框
+    /// 细分隔线（行间）
+    static let hairline = Color.black.opacity(0.08)
+    /// 卡片 / 控件描边
+    static let cardBorder = Color.black.opacity(0.13)
+
+    // MARK: - 字号
+    /// 全局字号缩放：界面整体偏小/偏大时，只调这一个值。
+    /// 设计稿基准字号偏小（为网页原型设定），在真实 macOS 上整体放大。
+    static let fontScale: CGFloat = 1.15
+    /// 把设计稿基准字号按全局缩放换算为实际点数。
+    static func fs(_ base: CGFloat) -> CGFloat { base * fontScale }
+
+    // MARK: - 圆角
+    enum Radius {
+        static let card: CGFloat = 9
+        static let row: CGFloat = 6
+        static let chip: CGFloat = 5
+        static let statusCard: CGFloat = 8
+        static let inset: CGFloat = 7
+        static let keycap: CGFloat = 4
+    }
+}
+
+/// 快捷键键帽：等宽小字、浅底细边圆角。
+///
+/// 用于右侧面板各行与底部按钮，显式展示现有快捷键。
+struct Keycap: View {
+    let text: String
+    /// 主按钮上的键帽用半透明白色，其余用默认灰。
+    var onAccent: Bool = false
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: Theme.fs(9.5), weight: .semibold, design: .monospaced))
+            .foregroundColor(onAccent ? Color.white.opacity(0.9) : Color(hex: 0x5B5B60))
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(
+                RoundedRectangle(cornerRadius: Theme.Radius.keycap)
+                    .fill(onAccent ? Color.white.opacity(0.18) : Color.black.opacity(0.05))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.keycap)
+                    .stroke(onAccent ? Color.white.opacity(0.3) : Color.black.opacity(0.1), lineWidth: 0.5)
+            )
+    }
+}
+
+/// 分组小标题：大写灰色细标签，用于右栏 / 评论区各块上方。
+struct GroupHeader: View {
+    let text: String
+    var color: Color = Theme.groupHeader
+
+    init(_ text: String, color: Color = Theme.groupHeader) {
+        self.text = text
+        self.color = color
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: Theme.fs(9.5), weight: .bold))
+            .foregroundColor(color)
+            .textCase(.uppercase)
+    }
+}
+
+extension View {
+    /// 白色圆角卡 + 细描边（右栏分组、列表容器用）。
+    func sectionCard(cornerRadius: CGFloat = Theme.Radius.card) -> some View {
+        self
+            .background(Theme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(Theme.cardBorder, lineWidth: 1)
+            )
+    }
+
+    /// 浅底内嵌框：圆角 7 + 细边（评论区各块、着法/变招列表区域用）。
+    func insetBox(background: Color = Theme.insetBackground, border: Color = Theme.cardBorder) -> some View {
+        self
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.inset))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.inset)
+                    .stroke(border, lineWidth: 1)
+            )
+    }
+}
+
+extension String {
+    /// 把 ASCII 阿拉伯数字转成全角（０-９），让着法记谱每步等宽、纵向成列。
+    var fullwidthDigits: String {
+        String(unicodeScalars.map { scalar in
+            (scalar.value >= 48 && scalar.value <= 57)
+                ? Unicode.Scalar(scalar.value - 48 + 0xFF10)!
+                : scalar
+        }.map(Character.init))
+    }
+}
+
+extension Color {
+    /// 用 0xRRGGBB 形式的整型十六进制构造颜色，可选透明度。
+    init(hex: UInt32, alpha: Double = 1) {
+        let r = Double((hex >> 16) & 0xFF) / 255
+        let g = Double((hex >> 8) & 0xFF) / 255
+        let b = Double(hex & 0xFF) / 255
+        self.init(.sRGB, red: r, green: g, blue: b, opacity: alpha)
+    }
+}

--- a/XiangqiNotebook/Views/FlowLayout.swift
+++ b/XiangqiNotebook/Views/FlowLayout.swift
@@ -8,8 +8,17 @@ private struct FlowLayoutEngine: Layout {
     var verticalSpacing: CGFloat
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let containerWidth = proposal.width ?? .infinity
-        let rows = computeRows(subviews: subviews, containerWidth: containerWidth)
+        // 关键：当父布局以未指定/无穷大宽度来测量理想尺寸时，绝不能返回无穷大宽度，
+        // 否则该无穷大会沿父链向上传播，挤占同级列（着法列、右栏）的宽度，
+        // 使其文字被压成 0 宽而“消失”。此时以最宽子项作为理想宽度，逐项竖排。
+        let resolvedWidth: CGFloat
+        if let width = proposal.width, width.isFinite {
+            resolvedWidth = width
+        } else {
+            resolvedWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? 0
+        }
+
+        let rows = computeRows(subviews: subviews, containerWidth: resolvedWidth)
         var totalHeight: CGFloat = 0
         for (index, row) in rows.enumerated() {
             let rowHeight = row.map { $0.size.height }.max() ?? 0
@@ -18,7 +27,7 @@ private struct FlowLayoutEngine: Layout {
                 totalHeight += verticalSpacing
             }
         }
-        return CGSize(width: containerWidth, height: totalHeight)
+        return CGSize(width: resolvedWidth, height: totalHeight)
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {

--- a/XiangqiNotebook/Views/GameResultColor.swift
+++ b/XiangqiNotebook/Views/GameResultColor.swift
@@ -15,3 +15,60 @@ extension GameResult {
         }
     }
 }
+
+/// 从用户视角（执红/执黑）看的战绩结果，用于棋谱行右侧的胜/负/和 chip。
+enum UserOutcome {
+    case win, loss, draw
+
+    var label: String {
+        switch self {
+        case .win: return "胜"
+        case .loss: return "负"
+        case .draw: return "和"
+        }
+    }
+
+    var foreground: Color {
+        switch self {
+        case .win: return Theme.good
+        case .loss: return Theme.bad
+        case .draw: return Theme.textSecondary
+        }
+    }
+
+    var background: Color {
+        switch self {
+        case .win: return Color(hex: 0x34C759, alpha: 0.14)
+        case .loss: return Color(hex: 0xFF3B30, alpha: 0.13)
+        case .draw: return Color(hex: 0x787880, alpha: 0.16)
+        }
+    }
+}
+
+extension GameObject {
+    /// 用户在该实战棋局中的结果；非实战或结果未知时为 nil。
+    var userOutcome: UserOutcome? {
+        guard iAmRed || iAmBlack else { return nil }
+        switch gameResult {
+        case .draw: return .draw
+        case .redWin: return iAmRed ? .win : .loss
+        case .blackWin: return iAmBlack ? .win : .loss
+        case .notFinished, .unknown: return nil
+        }
+    }
+}
+
+/// 胜/负/和 战绩 chip。
+struct OutcomeChip: View {
+    let outcome: UserOutcome
+
+    var body: some View {
+        Text(outcome.label)
+            .font(.system(size: Theme.fs(10), weight: .semibold))
+            .foregroundColor(outcome.foreground)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(outcome.background)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.chip))
+    }
+}

--- a/XiangqiNotebook/Views/Mac/GameBrowserView.swift
+++ b/XiangqiNotebook/Views/Mac/GameBrowserView.swift
@@ -1160,12 +1160,25 @@ struct GameBrowserSidebarView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Text("棋局浏览器")
-                    .font(.headline)
-                    .padding(.horizontal)
-                    .padding(.top)
+                GroupHeader("棋局浏览器")
                 Spacer()
+                // 收起侧栏（对应动作 toggleGameBrowserSidebar / ,gb）
+                Button(action: {
+                    if let info = viewModel.actionDefinitions.getToggleActionInfo(.toggleGameBrowserSidebar) {
+                        ShortcutUsageStats.shared.recordFromButton(.toggleGameBrowserSidebar)
+                        info.action(false)
+                    }
+                }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: Theme.fs(11), weight: .semibold))
+                        .foregroundColor(Theme.textSecondary)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 2) {
@@ -1195,10 +1208,10 @@ struct GameBrowserSidebarView: View {
                         }
                     }
                 }
-                .padding(.horizontal)
+                .padding(.horizontal, 8)
             }
         }
-        .background(Color.adaptiveBackground)
+        .background(Theme.sidebarBackground)
         .onAppear {
             expandedBookIds = viewModel.gameBrowserExpandedBookIds
         }
@@ -1231,7 +1244,7 @@ private struct SidebarBookRowView: View {
                 }
             }) {
                 Image(systemName: !hasChildren ? "circle" : (isExpanded ? "chevron.down" : "chevron.right"))
-                    .font(.system(size: 10))
+                    .font(.system(size: Theme.fs(10)))
                     .foregroundColor(.secondary)
                     .frame(width: 16, height: 16)
                     .contentShape(Rectangle())
@@ -1240,17 +1253,18 @@ private struct SidebarBookRowView: View {
             .disabled(!hasChildren)
 
             Image(systemName: "folder.fill")
-                .foregroundColor(.blue)
-                .font(.system(size: 12))
+                .foregroundColor(Theme.accent)
+                .font(.system(size: Theme.fs(12)))
 
             Text(book.name)
-                .font(.system(size: 12))
+                .font(.system(size: Theme.fs(12.5), weight: .medium))
+                .foregroundColor(Theme.textPrimary)
                 .lineLimit(1)
 
             Spacer()
         }
-        .padding(.vertical, 3)
-        .padding(.horizontal, 4)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
         .contentShape(Rectangle())
         .onTapGesture {
             withAnimation(.easeInOut(duration: 0.2)) {
@@ -1285,16 +1299,20 @@ private struct SidebarGameRowView: View {
 
                 HStack(spacing: 6) {
                     Image(systemName: "doc.text")
-                        .foregroundColor(.orange)
-                        .font(.system(size: 11))
+                        .foregroundColor(isCurrentGame ? .white : Color(hex: 0xE0A93B))
+                        .font(.system(size: Theme.fs(11)))
                     Text(game.displayTitle)
-                        .font(.system(size: 12, weight: isSelected ? .medium : .regular))
+                        .font(.system(size: Theme.fs(12.5), weight: isSelected ? .medium : .regular))
+                        .foregroundColor(isCurrentGame ? .white : Theme.textPrimary)
                         .lineLimit(1)
-                    Spacer()
+                    Spacer(minLength: 4)
+                    if let outcome = game.userOutcome {
+                        OutcomeChip(outcome: outcome)
+                    }
                 }
             }
-            .padding(.horizontal, 4)
-            .padding(.vertical, 3)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
 
             if isSelected {
                 HStack(spacing: 0) {
@@ -1311,27 +1329,27 @@ private struct SidebarGameRowView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         if !game.redPlayerName.isEmpty || !game.blackPlayerName.isEmpty {
                             Text("\(game.redPlayerName.isEmpty ? "?" : game.redPlayerName) vs \(game.blackPlayerName.isEmpty ? "?" : game.blackPlayerName)")
-                                .font(.system(size: 11))
+                                .font(.system(size: Theme.fs(11)))
                                 .foregroundColor(.secondary)
                         }
 
                         HStack(spacing: 6) {
                             if let date = game.gameDate {
                                 Text(date, style: .date)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: Theme.fs(11)))
                                     .foregroundColor(.secondary)
                             }
 
                             if game.gameResult != .unknown {
                                 Text(game.gameResult.rawValue)
-                                    .font(.system(size: 10, weight: .medium))
+                                    .font(.system(size: Theme.fs(10), weight: .medium))
                                     .foregroundColor(.secondary)
                             }
                         }
 
                         Button(action: onLoad) {
                             Text("加载棋局")
-                                .font(.system(size: 11))
+                                .font(.system(size: Theme.fs(11)))
                         }
                         .buttonStyle(.plain)
                         .foregroundColor(.accentColor)
@@ -1345,8 +1363,8 @@ private struct SidebarGameRowView: View {
             }
         }
         .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(isCurrentGame ? Color.accentColor.opacity(0.2) : (isSelected ? Color.secondary.opacity(0.1) : Color.clear))
+            RoundedRectangle(cornerRadius: Theme.Radius.row)
+                .fill(isCurrentGame ? Theme.accent : (isSelected ? Color.black.opacity(0.05) : Color.clear))
         )
         .contentShape(Rectangle())
         .onTapGesture {

--- a/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
+++ b/XiangqiNotebook/Views/Mac/MacActionButtonsView.swift
@@ -2,7 +2,11 @@
 import SwiftUI
 import AppKit
 
-/// 按钮区域组件
+/// 底部按钮区组件
+///
+/// 视觉改版：两行等宽对齐网格（行 1 不足处留空位补齐）；每个按钮单行「文字 + 键帽」，
+/// 高约 30；所有按钮统一为普通样式（不做单独高亮，避免被误读成激活态）。
+/// 整条工具栏用渐变底 + 顶部细分隔线。
 struct MacActionButtonsView: View {
     @ObservedObject var viewModel: ViewModel
 
@@ -59,7 +63,7 @@ struct MacActionButtonsView: View {
         }
     }
 
-    /// 最大可见按钮数量
+    /// 最大可见按钮数量（决定网格列数，保证两行对齐）
     private var maxVisibleCount: Int {
         buttonRows.map { visibleKeys(for: $0).count }.max() ?? 0
     }
@@ -70,22 +74,23 @@ struct MacActionButtonsView: View {
         let visible = visibleKeys(for: keys)
         let padding = maxVisibleCount - visible.count
 
-        HStack {
+        HStack(spacing: 5) {
             // 只渲染可见的按钮
             ForEach(Array(visible.enumerated()), id: \.offset) { _, key in
-                LargeButton(viewModel: viewModel, actionKey: key)
+                MacToolbarButton(viewModel: viewModel, actionKey: key)
                     .frame(maxWidth: .infinity)
             }
             // 补齐空占位符
             ForEach(0..<padding, id: \.self) { _ in
-                LargeButton(viewModel: viewModel, actionKey: nil)
+                Color.clear
                     .frame(maxWidth: .infinity)
+                    .frame(height: 30)
             }
         }
     }
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 5) {
             ForEach(Array(buttonRows.enumerated()), id: \.offset) { _, rowKeys in
                 let visible = visibleKeys(for: rowKeys)
                 if !visible.isEmpty {
@@ -93,8 +98,70 @@ struct MacActionButtonsView: View {
                 }
             }
         }
-        .padding(8)
-        .border(Color.gray)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(
+            LinearGradient(
+                colors: [Color(hex: 0xF8F8FA), Color(hex: 0xEEEEF1)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.black.opacity(0.12))
+                .frame(height: 0.5)
+        }
+    }
+}
+
+/// 底部工具栏的单个按钮：文字 + 键帽，单行。
+private struct MacToolbarButton: View {
+    @ObservedObject var viewModel: ViewModel
+    let actionKey: ActionDefinitions.ActionKey
+
+    var body: some View {
+        let info: ActionDefinitions.ActionInfo? = viewModel.isActionVisible(actionKey)
+            ? viewModel.actionDefinitions.getActionInfo(actionKey)
+            : nil
+
+        Button(action: {
+            ShortcutUsageStats.shared.recordFromButton(actionKey)
+            info?.action()
+        }) {
+            HStack(spacing: 5) {
+                Text(info?.text ?? "")
+                    .font(.system(size: Theme.fs(12.5), weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let shortcut = info?.shortcutsDisplayText {
+                    Keycap(text: shortcut)
+                }
+            }
+            .foregroundColor(Theme.textPrimary)
+            .frame(maxWidth: .infinity)
+            .frame(height: 30)
+            .padding(.horizontal, 6)
+        }
+        .buttonStyle(MacToolbarButtonStyle())
+        .disabled(info == nil)
+    }
+}
+
+/// 工具栏按钮样式：圆角浅底细边 + 轻投影，所有按钮统一。
+private struct MacToolbarButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: Theme.Radius.row)
+                    .fill(configuration.isPressed ? Color.black.opacity(0.06) : Theme.cardBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.row)
+                    .stroke(Color.black.opacity(0.14), lineWidth: 0.5)
+            )
+            .shadow(color: Color.black.opacity(0.07), radius: 0.75, y: 1)
     }
 }
 
@@ -102,6 +169,6 @@ struct MacActionButtonsView: View {
     MacActionButtonsView(viewModel: ViewModel(
         platformService: MacOSPlatformService()
     ))
-} 
+}
 
 #endif

--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -23,47 +23,71 @@ struct MacContentView: View {
         isViewFocused = true
     }
     
+    /// 弹性列宽：clamp(min, 比例, max)
+    private func clampWidth(_ total: CGFloat, ratio: CGFloat, min minW: CGFloat, max maxW: CGFloat) -> CGFloat {
+        Swift.min(maxW, Swift.max(minW, total * ratio))
+    }
+
     var body: some View {
         GeometryReader { geometry in
+            // 侧栏 / 着法列 / 右栏：确定宽度且更高布局优先级，HStack 先把它们排满，
+            // 棋盘栏拿剩余空间（最低优先级），因此列宽只随窗口宽度变化，既不会被
+            // 评论区内容反向挤压而随局面漂移，也不会在窄窗口下被压成空白。
+            // 各列 min/max 随字号缩放，避免放大字体后窄列装不下内容。
+            let totalWidth = geometry.size.width
+            let sidebarShown = viewModel.showGameBrowserSidebar
+            let sidebarWidth = sidebarShown ? clampWidth(totalWidth, ratio: 0.15, min: Theme.fs(178), max: Theme.fs(238)) : 0
+            let middleWidth = clampWidth(totalWidth, ratio: 0.17, min: Theme.fs(208), max: Theme.fs(272))
+            let rightWidth = clampWidth(totalWidth, ratio: 0.18, min: Theme.fs(220), max: Theme.fs(288))
+
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
-                    // 棋局浏览器侧栏
-                    if viewModel.showGameBrowserSidebar {
+                    // 棋局浏览器侧栏（弹性宽度 clamp(178, 15%, 238)，可折叠）
+                    if sidebarShown {
                         GameBrowserSidebarView(viewModel: viewModel)
-                            .frame(width: 250)
+                            .frame(width: sidebarWidth)
+                            .layoutPriority(1)
                         Divider()
                     }
 
                     // 左侧区域：棋盘
                     VStack(spacing: 0) {
-                        // 棋盘 - 设置为屏幕高度的一半
+                        // 棋盘 - 按可用空间等比缩放并居中（内部 aspectRatio .fit），
+                        // 多余的纵向空间留给它，而不是堆给评论区
                         XiangqiBoard(viewModel: $viewModel.boardViewModel, onMove: { newFen in
                             viewModel.handleBoardMove(newFen)
                         })
-                        .frame(height: geometry.size.height * 0.5)  // 设置为屏幕高度的50%
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                         // 状态栏 - 保持固定高度
                         StatusBarView(viewModel: viewModel)
 
-                        // 评论区 - 分配剩余空间
+                        // 评论区 - 限高，避免空评论框过高
                         CommentView(viewModel: viewModel)
-                            .frame(maxHeight: .infinity)
+                            .frame(maxHeight: geometry.size.height * 0.30)
                     }
                     .frame(maxWidth: .infinity)
+                    .clipped()
+                    .background(Theme.centerBackground)
 
-                    // 中间区域：开局库和书签
+                    Divider()
+
+                    // 中间区域：着法列 + 变招（弹性宽度 clamp(208, 17%, 272)）
+                    // 着法列表 / 本步变招 / 下步变招 三段上下竖排，各占满整列宽度，
+                    // 这样变招行能拿到完整列宽，分数不会因列太窄被截断或换行。
                     VStack(spacing: 0) {
                         MoveListView(viewModel: viewModel)
-                            .frame(width: geometry.size.width * 0.2)
-
-                        // 变着列表 + 下一步招法列表（左右并排）
-                        HStack(spacing: 0) {
-                            VariantListView(viewModel: viewModel)
-                            NextMovesListView(viewModel: viewModel)
-                        }
-                        .frame(height: geometry.size.height * 0.25)
+                            .frame(maxHeight: .infinity)
+                        VariantListView(viewModel: viewModel)
+                            .frame(height: geometry.size.height * 0.18)
+                        NextMovesListView(viewModel: viewModel)
+                            .frame(height: geometry.size.height * 0.18)
                     }
-                    .frame(width: geometry.size.width * 0.2)
+                    .frame(width: middleWidth)
+                    .layoutPriority(1)
+                    .background(Theme.sidebarBackground)
+
+                    Divider()
 
                     // 右侧区域
                     if viewModel.isInVerificationMode {
@@ -78,7 +102,9 @@ struct MacContentView: View {
                             .frame(maxHeight: .infinity)
                             BoardOperationTogglesView(viewModel: viewModel)
                         }
-                        .frame(width: geometry.size.width * 0.2)
+                        .frame(width: rightWidth)
+                    .layoutPriority(1)
+                    .background(Theme.sidebarBackground)
                     } else if viewModel.isInReviewMode {
                         // 复习模式：复习面板 + 复习库列表（填满） + 棋盘操作（底部）
                         VStack(spacing: 0) {
@@ -91,7 +117,9 @@ struct MacContentView: View {
                             .frame(maxHeight: .infinity)
                             BoardOperationTogglesView(viewModel: viewModel)
                         }
-                        .frame(width: geometry.size.width * 0.2)
+                        .frame(width: rightWidth)
+                    .layoutPriority(1)
+                    .background(Theme.sidebarBackground)
                     } else {
                         // 常规/练习模式：ScrollView 包裹
                         ScrollView {
@@ -104,7 +132,9 @@ struct MacContentView: View {
                                 }
                             }
                         }
-                        .frame(width: geometry.size.width * 0.2)
+                        .frame(width: rightWidth)
+                    .layoutPriority(1)
+                    .background(Theme.sidebarBackground)
                     }
                 }
 

--- a/XiangqiNotebook/Views/ModeSelectorView.swift
+++ b/XiangqiNotebook/Views/ModeSelectorView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// 模式选择器组件
-/// 显示当前模式，支持模式切换
+/// 显示当前模式，支持模式切换；视觉改版为单选（radio）样式。
 struct ModeSelectorView: View {
     @ObservedObject var viewModel: ViewModel
 
@@ -12,15 +12,65 @@ struct ModeSelectorView: View {
     ]
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("应用模式")
+        VStack(alignment: .leading, spacing: 6) {
+            GroupHeader("应用模式")
+                .padding(.horizontal, 2)
 
-            ForEach(Self.modeActionKeys, id: \.self) { key in
-                MyToggle(viewModel: viewModel, actionKey: key)
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Self.modeActionKeys, id: \.self) { key in
+                    ModeRadioRow(viewModel: viewModel, actionKey: key)
+                }
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .sectionCard()
         }
         .padding(8)
-        .border(Color.gray)
+    }
+}
+
+/// 单选行：蓝心圆 radio + 标签 + 右端快捷键键帽。
+struct ModeRadioRow: View {
+    @ObservedObject var viewModel: ViewModel
+
+    let toggleActionInfo: ActionDefinitions.ToggleActionInfo
+    let actionKey: ActionDefinitions.ActionKey
+
+    init(viewModel: ViewModel, actionKey: ActionDefinitions.ActionKey) {
+        self.viewModel = viewModel
+        self.actionKey = actionKey
+        self.toggleActionInfo = viewModel.actionDefinitions.getToggleActionInfo(actionKey)!
+    }
+
+    private var isOn: Bool { toggleActionInfo.isOn() }
+    private var isDisabled: Bool {
+        !viewModel.isActionVisible(actionKey) || !toggleActionInfo.isEnabled()
+    }
+
+    var body: some View {
+        Button(action: {
+            ShortcutUsageStats.shared.recordFromButton(actionKey)
+            toggleActionInfo.action(true)
+        }) {
+            HStack(spacing: 7) {
+                Image(systemName: isOn ? "largecircle.fill.circle" : "circle")
+                    .font(.system(size: Theme.fs(13)))
+                    .foregroundColor(isOn ? Theme.accent : Theme.placeholder)
+                Text(toggleActionInfo.text)
+                    .font(.system(size: Theme.fs(12.5)))
+                    .foregroundColor(Theme.textPrimary)
+                    .lineLimit(1)
+                Spacer(minLength: 6)
+                if let shortcut = toggleActionInfo.shortcutsDisplayText {
+                    Keycap(text: shortcut)
+                        .opacity(isDisabled ? 0.4 : 1)
+                }
+            }
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
     }
 }
 

--- a/XiangqiNotebook/Views/MoveListView.swift
+++ b/XiangqiNotebook/Views/MoveListView.swift
@@ -9,44 +9,49 @@ struct MoveListView: View {
             ScrollView(showsIndicators: true) {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(viewModel.currentGameMoveListDisplay.enumerated()), id: \.offset) { index, item in
-                        HStack(spacing: 8) {
-                            // 第一列：序号（右对齐，紧凑固定宽度）
+                        HStack(spacing: 6) {
+                            // 第一列：序号（右对齐，紧凑固定宽度；宽度随字号缩放）
                             Text(item.number)
-                                .frame(width: 32, alignment: .trailing)
+                                .frame(width: Theme.fs(32), alignment: .trailing)
                                 .monospacedDigit()
+                                .lineLimit(1)
+                                .foregroundColor(Theme.textSecondary)
 
-                            // 第二列：招法（左对齐，固定宽度容纳4个字符）
-                            Text(item.notation)
-                                .frame(width: 52, alignment: .leading)
+                            // 第二列：招法（左对齐，全角数字等宽，固定宽度容纳4个字符）
+                            Text(item.notation.fullwidthDigits)
+                                .frame(width: Theme.fs(58), alignment: .leading)
+                                .lineLimit(1)
 
                             // 第三列：红方开局库标识（居中对齐，固定宽度）
                             Text(item.redOpeningMarker)
-                                .frame(width: 8, alignment: .center)
-                                .foregroundColor(.secondary)
+                                .frame(width: Theme.fs(9), alignment: .center)
+                                .foregroundColor(Theme.textSecondary)
 
                             // 第四列：黑方开局库标识（居中对齐，固定宽度）
                             Text(item.blackOpeningMarker)
-                                .frame(width: 8, alignment: .center)
-                                .foregroundColor(.secondary)
+                                .frame(width: Theme.fs(9), alignment: .center)
+                                .foregroundColor(Theme.textSecondary)
 
                             // 第五列：复习库标识（居中对齐，固定宽度）
                             Text(item.reviewMarker)
-                                .frame(width: 8, alignment: .center)
-                                .foregroundColor(.secondary)
+                                .frame(width: Theme.fs(9), alignment: .center)
+                                .foregroundColor(Theme.textSecondary)
 
                             // 第六列：变着标记（左对齐，获得剩余空间）
                             Text(item.markers)
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                                .foregroundColor(Theme.placeholder)
                         }
-                        .padding(.vertical, 2)
-                        .padding(.horizontal, 4)
+                        .font(.system(size: Theme.fs(12.5)))
+                        .padding(.vertical, 3)
+                        .padding(.horizontal, 6)
                         .background(
                             Group {
                                 if viewModel.currentGameStepDisplay == index {
-                                    Color.blue.opacity(0.2)
+                                    Theme.accent.opacity(0.12)
                                 } else if viewModel.isMoveLocked(index) {
-                                    Color.gray.opacity(0.2)
+                                    Color.black.opacity(0.05)
                                 } else {
                                     Color.clear
                                 }
@@ -54,17 +59,17 @@ struct MoveListView: View {
                         )
                         .foregroundColor(item.move.map { move in
                             if viewModel.isBadMove(move) {
-                                return .red
+                                return Theme.bad
                             } else if viewModel.isRecommendedMove(move) {
-                                return .green
+                                return Theme.good
                             }
-                            return .primary
-                        } ?? .primary)
+                            return Theme.textPrimary
+                        } ?? Theme.textPrimary)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             viewModel.toStepIndex(index)
                         }
-                        Divider()  // 添加分隔线
+                        Divider().overlay(Theme.hairline)  // 添加分隔线
                     }
                 }
                 // scrollPosition(id:) 必须配套 scrollTargetLayout 才能定位条目
@@ -73,8 +78,9 @@ struct MoveListView: View {
             // scrollPosition 必须挂在 ScrollView 上（原先挂在外层 VStack 上无效）
             .scrollPosition(id: .constant(viewModel.currentGameStepDisplay))
         }
-        .padding() // 添加内边距，让内容不贴边
-        .border(Color.gray)
+        .padding(6) // 添加内边距，让内容不贴边
+        .sectionCard()
+        .padding(6)
     }
 }
 

--- a/XiangqiNotebook/Views/StatusBarView.swift
+++ b/XiangqiNotebook/Views/StatusBarView.swift
@@ -1,175 +1,217 @@
 import SwiftUI
 
 /// 状态栏组件
+///
+/// 视觉改版：原先 3 个独立灰边框合并为一张圆角状态卡（`#FAFAFA` + 0.5px 细边），
+/// 内部 3 行用细分隔线分隔；第 2、3 行的信息项两端均匀分布（space-between）铺满整行。
 struct StatusBarView: View {
     @ObservedObject var viewModel: ViewModel
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    
-    // 根据平台确定字体样式
-    private var fontStyle: Font {
-        #if os(iOS)
-        // 在 iOS 上使用 caption 字体，它会根据用户的设置自动调整大小
-        return .caption
-        #else
-        // 在 macOS 上使用 body 字体
-        return .body
-        #endif
-    }
-    
-    // 根据动态类型大小调整内边距
-    private var verticalPadding: CGFloat {
-        switch dynamicTypeSize {
-        case .xSmall, .small, .medium:
-            return 6
-        case .large, .xLarge:
-            return 8
-        default:
-            return 10
-        }
-    }
-    
-    private func gameStatRow(_ label: String, total: Int, wins: Int, draws: Int, losses: Int) -> some View {
-        HStack(spacing: 4) {
-            Text(label)
-            Text("总")
-            Text("\(total)").frame(minWidth: 24, alignment: .leading)
-            Text("胜")
-            Text("\(wins)").frame(minWidth: 24, alignment: .leading)
-            Text("和")
-            Text("\(draws)").frame(minWidth: 24, alignment: .leading)
-            Text("负")
-            Text("\(losses)").frame(minWidth: 24, alignment: .leading)
-        }
-        .font(fontStyle)
+
+    // MARK: - 颜色
+
+    /// 当前着法分数着色：坏棋红、荐着绿、其余主色
+    private var currentScoreColor: Color {
+        viewModel.isCurrentMoveBad ? Theme.bad : (viewModel.isCurrentMoveRecommended ? Theme.good : Theme.textPrimary)
     }
 
-    private var quickEngineScoreText: Text {
+    // MARK: - 文本构件
+
+    /// 信息项：次要色标签 + 主色（或着色）数值，等宽数字、单行。
+    private func stat(_ label: String, _ value: Text) -> some View {
+        (Text(label + " ")
+            .font(.system(size: Theme.fs(11.5)))
+            .foregroundColor(Theme.textSecondary)
+            + value)
+            .monospacedDigit()
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+
+    private func value(_ string: String, color: Color = Theme.textPrimary) -> Text {
+        Text(string)
+            .font(.system(size: Theme.fs(11.5), weight: .semibold))
+            .foregroundColor(color)
+    }
+
+    /// 引擎评分数值（带评估中 / 等待中状态）
+    private func engineValue(idle: String) -> Text {
+        value(idle, color: currentScoreColor)
+    }
+
+    private var quickEngineValue: Text {
         #if os(macOS)
         switch viewModel.currentFenQuickEvalStatus {
-        case .evaluating:
-            return Text("皮卡鱼快估: 评估中...").foregroundColor(.orange)
-        case .queued:
-            return Text("皮卡鱼快估: 等待中...").foregroundColor(.gray)
-        case .idle:
-            return Text("皮卡鱼快估: \(viewModel.displayQuickEngineScore)")
-                .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))
+        case .evaluating: return value("评估中…", color: .orange)
+        case .queued: return value("等待中…", color: Theme.textSecondary)
+        case .idle: return engineValue(idle: viewModel.displayQuickEngineScore)
         }
         #else
-        return Text("皮卡鱼快估: \(viewModel.displayQuickEngineScore)")
-            .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))
+        return engineValue(idle: viewModel.displayQuickEngineScore)
         #endif
     }
 
-    private var deepEngineScoreText: Text {
+    private var deepEngineValue: Text {
         #if os(macOS)
         switch viewModel.currentFenDeepEvalStatus {
-        case .evaluating:
-            return Text("皮卡鱼深评: 评估中...").foregroundColor(.orange)
-        case .queued:
-            return Text("皮卡鱼深评: 等待中...").foregroundColor(.gray)
-        case .idle:
-            return Text("皮卡鱼深评: \(viewModel.displayDeepEngineScore)")
-                .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))
+        case .evaluating: return value("评估中…", color: .orange)
+        case .queued: return value("等待中…", color: Theme.textSecondary)
+        case .idle: return engineValue(idle: viewModel.displayDeepEngineScore)
         }
         #else
-        return Text("皮卡鱼深评: \(viewModel.displayDeepEngineScore)")
-            .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))
+        return engineValue(idle: viewModel.displayDeepEngineScore)
         #endif
     }
 
-    var body: some View {
-        VStack {
-            HStack {
-                Text("FEN: \(viewModel.displayFen)")
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-                if !viewModel.currentMoveUCCI.isEmpty {
-                    Text("UCCI: \(viewModel.currentMoveUCCI)")
-                        .font(fontStyle)
-                }
-            }
-            .padding(.vertical, verticalPadding)
-            .padding(.horizontal)
-            .border(Color.gray)
-
-            HStack {
-                Text("下步走子: \(viewModel.isRedTurn ? "红方" : "黑方")")
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text("云库分数: \(viewModel.displayScore)")
-                    .font(fontStyle)
-                    .foregroundColor(viewModel.isCurrentMoveBad ? .red : (viewModel.isCurrentMoveRecommended ? .green : .primary))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                quickEngineScoreText
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                deepEngineScoreText
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text("步数: \(viewModel.currentGameStepDisplay) / \(viewModel.maxGameStepDisplay) / \(viewModel.gameStepLimitation?.description ?? "")")
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text("本变: \(viewModel.currentVariationIndex + 1) / \(viewModel.totalVariationsCount)")
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                if viewModel.currentAppMode == .practice {
-                    Text("局数: \(viewModel.totalPathsCountFromCurrentFen.map { String($0) } ?? "?")")
-                        .font(fontStyle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text("路径: \(viewModel.currentPathIndexDisplay.map { String($0 + 1) } ?? "?") / \(viewModel.totalPathsCount.map { String($0) } ?? "?")")
-                        .font(fontStyle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
-            .padding(.vertical, verticalPadding)
-            .padding(.horizontal)
-            .border(Color.gray)
-            // 确保文本在空间不足时能够适当缩小
+    /// 战绩：执红 / 执黑 一行，胜数用绿色，其余主色。
+    private func gameStat(_ label: String, total: Int, wins: Int, draws: Int, losses: Int) -> some View {
+        (Text(label + " ").font(.system(size: Theme.fs(11.5))).foregroundColor(Theme.textSecondary)
+            + Text("总").font(.system(size: Theme.fs(11.5))).foregroundColor(Theme.textSecondary)
+            + value("\(total)")
+            + Text(" 胜").font(.system(size: Theme.fs(11.5))).foregroundColor(Theme.textSecondary)
+            + value("\(wins)", color: wins > 0 ? Theme.good : Theme.textPrimary)
+            + Text(" 和").font(.system(size: Theme.fs(11.5))).foregroundColor(Theme.textSecondary)
+            + value("\(draws)")
+            + Text(" 负").font(.system(size: Theme.fs(11.5))).foregroundColor(Theme.textSecondary)
+            + value("\(losses)", color: losses > 0 ? Theme.bad : Theme.textPrimary))
+            .monospacedDigit()
             .lineLimit(1)
-            // .minimumScaleFactor(0.75)
+            .truncationMode(.tail)
+    }
 
-            HStack(spacing: 0) {
-                gameStatRow("执红实战:", total: viewModel.currentFenInRealRedGameTotalCount, wins: viewModel.currentFenInRealRedGameWinCount, draws: viewModel.currentFenInRealRedGameDrawCount, losses: viewModel.currentFenInRealRedGameLossCount)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                gameStatRow("执黑实战:", total: viewModel.currentFenInRealBlackGameTotalCount, wins: viewModel.currentFenInRealBlackGameWinCount, draws: viewModel.currentFenInRealBlackGameDrawCount, losses: viewModel.currentFenInRealBlackGameLossCount)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text("练习次数: \(viewModel.currentFenPracticeCount)")
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text("数据: \(String(viewModel.currentDataVersion))\(viewModel.currentDatabaseDirty ? "*" : " ")")
-                    .font(fontStyle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                #if os(macOS)
-                if let queue = viewModel.evaluationQueue, !queue.state.isIdle {
-                    HStack(spacing: 4) {
-                        Text("评估 \(queue.state.completedCount)/\(queue.state.totalEnqueued)")
-                            .font(fontStyle)
-                        if let detail = queue.state.currentDetail {
-                            Text(detail)
-                                .font(fontStyle)
-                                .foregroundStyle(.secondary)
-                        }
-                        Button("取消") {
-                            viewModel.cancelEvaluation()
-                        }
-                        .font(fontStyle)
-                        .buttonStyle(.plain)
-                        .foregroundColor(.red)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                #endif
+    // MARK: - 行
+
+    /// 行 1：FEN（等宽，超出省略）+ 右侧 UCCI
+    private var fenRow: some View {
+        HStack(spacing: 7) {
+            Text("FEN")
+                .font(.system(size: Theme.fs(9.5), weight: .bold))
+                .foregroundColor(Theme.groupHeader)
+            Text(viewModel.displayFen)
+                .font(.system(size: Theme.fs(10.5), design: .monospaced))
+                .foregroundColor(Theme.monoText)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if !viewModel.currentMoveUCCI.isEmpty {
+                Text("UCCI")
+                    .font(.system(size: Theme.fs(9.5), weight: .bold))
+                    .foregroundColor(Theme.groupHeader)
+                Text(viewModel.currentMoveUCCI)
+                    .font(.system(size: Theme.fs(10.5), design: .monospaced))
+                    .foregroundColor(Theme.monoText)
             }
-            .padding(.vertical, verticalPadding)
-            .padding(.horizontal)
-            .border(Color.gray)
-            // 确保文本在空间不足时能够适当缩小
-            .lineLimit(1)
-            .minimumScaleFactor(0.75)
         }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+    }
+
+    /// 行 2：下步走子 / 云库 / 快估 / 深评 / 步数 / 本变 / 路径，space-between
+    private var evalRow: some View {
+        HStack(spacing: 8) {
+            stat("下步走子", value(viewModel.isRedTurn ? "红方" : "黑方"))
+            Spacer(minLength: 6)
+            stat("云库", value(viewModel.displayScore, color: currentScoreColor))
+            Spacer(minLength: 6)
+            stat("快估", quickEngineValue)
+            Spacer(minLength: 6)
+            stat("深评", deepEngineValue)
+            Spacer(minLength: 6)
+            stat("步数", value("\(viewModel.currentGameStepDisplay)/\(viewModel.maxGameStepDisplay)\(viewModel.gameStepLimitation.map { "/\($0)" } ?? "")"))
+            Spacer(minLength: 6)
+            stat("本变", value("\(viewModel.currentVariationIndex + 1)/\(viewModel.totalVariationsCount)"))
+            Spacer(minLength: 6)
+            if viewModel.currentAppMode == .practice {
+                stat("局数", value(viewModel.totalPathsCountFromCurrentFen.map { String($0) } ?? "?"))
+            } else {
+                stat("路径", value("\(viewModel.currentPathIndexDisplay.map { String($0 + 1) } ?? "?")/\(viewModel.totalPathsCount.map { String($0) } ?? "?")"))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+
+    /// 行 3：执红 / 执黑 战绩 / 练习 / 数据 + 右端已保存指示
+    private var statsRow: some View {
+        HStack(spacing: 8) {
+            gameStat("执红", total: viewModel.currentFenInRealRedGameTotalCount, wins: viewModel.currentFenInRealRedGameWinCount, draws: viewModel.currentFenInRealRedGameDrawCount, losses: viewModel.currentFenInRealRedGameLossCount)
+            Spacer(minLength: 6)
+            gameStat("执黑", total: viewModel.currentFenInRealBlackGameTotalCount, wins: viewModel.currentFenInRealBlackGameWinCount, draws: viewModel.currentFenInRealBlackGameDrawCount, losses: viewModel.currentFenInRealBlackGameLossCount)
+            Spacer(minLength: 6)
+            stat("练习", value("\(viewModel.currentFenPracticeCount)"))
+            Spacer(minLength: 6)
+            stat("数据", value(String(viewModel.currentDataVersion)))
+            Spacer(minLength: 6)
+            #if os(macOS)
+            if let queue = viewModel.evaluationQueue, !queue.state.isIdle {
+                evaluationProgress(queue)
+                Spacer(minLength: 6)
+            }
+            #endif
+            savedIndicator
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+
+    /// 已保存 / 未保存指示
+    private var savedIndicator: some View {
+        let dirty = viewModel.currentDatabaseDirty
+        return HStack(spacing: 4) {
+            Circle()
+                .fill(dirty ? Theme.bad : Theme.savedDot)
+                .frame(width: 5, height: 5)
+            Text(dirty ? "未保存" : "已保存")
+                .font(.system(size: Theme.fs(11.5)))
+                .foregroundColor(dirty ? Theme.bad : Theme.good)
+        }
+        .fixedSize()
+    }
+
+    #if os(macOS)
+    @ViewBuilder
+    private func evaluationProgress(_ queue: EvaluationQueue) -> some View {
+        HStack(spacing: 4) {
+            Text("评估 \(queue.state.completedCount)/\(queue.state.totalEnqueued)")
+                .font(.system(size: Theme.fs(11.5)))
+                .foregroundColor(Theme.textSecondary)
+                .monospacedDigit()
+            if let detail = queue.state.currentDetail {
+                Text(detail)
+                    .font(.system(size: Theme.fs(11.5)))
+                    .foregroundStyle(.tertiary)
+            }
+            Button("取消") {
+                viewModel.cancelEvaluation()
+            }
+            .font(.system(size: Theme.fs(11.5)))
+            .buttonStyle(.plain)
+            .foregroundColor(Theme.bad)
+        }
+        .lineLimit(1)
+        .fixedSize()
+    }
+    #endif
+
+    // MARK: - body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            fenRow
+            Divider().overlay(Theme.hairline)
+            evalRow
+            Divider().overlay(Theme.hairline)
+            statsRow
+        }
+        .background(Theme.statusCardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.statusCard))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.statusCard)
+                .stroke(Color.black.opacity(0.16), lineWidth: 1)
+        )
+        // 卡底色与中间栏底色几乎一致，靠极淡投影把卡片“托”起来，避免读不出边界
+        .shadow(color: Color.black.opacity(0.05), radius: 1.5, y: 0.5)
+        .padding(.horizontal, 12)
+        .padding(.top, 8)
     }
 }
 
@@ -183,4 +225,4 @@ struct StatusBarView: View {
         platformService: IOSPlatformService(presentingViewController: UIViewController())
     ))
     #endif
-} 
+}

--- a/XiangqiNotebook/Views/TogglesView.swift
+++ b/XiangqiNotebook/Views/TogglesView.swift
@@ -5,11 +5,9 @@ struct TogglesView: View {
     @ObservedObject var viewModel: ViewModel
     
     var body: some View {
-        VStack {
+        VStack(spacing: 10) {
             // 棋局筛选
-            VStack(alignment: .leading) {
-                Text("棋局筛选")
-
+            ToggleGroup(title: "棋局筛选") {
                 MyToggle(viewModel: viewModel, actionKey: .setFilterNone)
                 MyToggle(viewModel: viewModel, actionKey: .toggleFilterRedOpeningOnly)
                 MyToggle(viewModel: viewModel, actionKey: .toggleFilterBlackOpeningOnly)
@@ -21,19 +19,35 @@ struct TogglesView: View {
                 MyToggle(viewModel: viewModel, actionKey: .toggleStepLimitation)
                 MyToggle(viewModel: viewModel, actionKey: .toggleLock)
             }
-            .padding(8) // 添加内边距，让内容不贴边
-            .border(Color.gray)
 
-            // 开局库设置区域
-            VStack(alignment: .leading) {
+            // 开局库 / 书签
+            ToggleGroup(title: "开局库 / 书签") {
                 MyToggle(viewModel: viewModel, actionKey: .inRedOpening)
                 MyToggle(viewModel: viewModel, actionKey: .inBlackOpening)
                 MyToggle(viewModel: viewModel, actionKey: .toggleBookmark)
             }
-            .padding(8) // 添加内边距，让内容不贴边
-            .border(Color.gray)
 
             BoardOperationTogglesView(viewModel: viewModel)
+        }
+        .padding(8)
+    }
+}
+
+/// 右栏分组容器：大写灰小标题 + 白色圆角卡（行间细分隔线由各行自身留白体现）。
+struct ToggleGroup<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            GroupHeader(title)
+                .padding(.horizontal, 2)
+            VStack(alignment: .leading, spacing: 0) {
+                content
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .sectionCard()
         }
     }
 }
@@ -43,7 +57,7 @@ struct BoardOperationTogglesView: View {
     @ObservedObject var viewModel: ViewModel
 
     var body: some View {
-        VStack(alignment: .leading) {
+        ToggleGroup(title: "棋盘操作") {
             MyToggle(viewModel: viewModel, actionKey: .flip)
             MyToggle(viewModel: viewModel, actionKey: .flipHorizontal)
             MyToggle(viewModel: viewModel, actionKey: .toggleAutoExtendGameWhenPlayingBoardFen)
@@ -56,8 +70,6 @@ struct BoardOperationTogglesView: View {
             MyToggle(viewModel: viewModel, actionKey: .toggleIsCommentEditing)
             MyToggle(viewModel: viewModel, actionKey: .toggleAllowAddingNewMoves)
         }
-        .padding(8)
-        .border(Color.gray)
     }
 }
 
@@ -74,6 +86,7 @@ struct MyToggle: View {
         self.toggleActionInfo = viewModel.actionDefinitions.getToggleActionInfo(actionKey)!
     }
 
+    /// 标签文本（含特定棋局/棋书名称、步数/锁定步数，但不含快捷键）
     var displayText: String {
         var text = toggleActionInfo.text
 
@@ -92,28 +105,68 @@ struct MyToggle: View {
             text += ": \(lockedStep)"
         }
 
-        if let displayText = toggleActionInfo.shortcutsDisplayText {
-            return "\(text) (\(displayText))"
-        }
         return text
     }
 
+    private var isDisabled: Bool {
+        !viewModel.isActionVisible(actionKey) || !toggleActionInfo.isEnabled()
+    }
+
+    private var isOn: Bool { toggleActionInfo.isOn() }
+
+    private func toggle() {
+        ShortcutUsageStats.shared.recordFromButton(actionKey)
+        toggleActionInfo.action(!isOn)
+    }
+
     var body: some View {
-        HStack {
+        #if os(macOS)
+        // macOS：自绘复选框（蓝底白勾）+ 标签 + 右端键帽。
+        // 不用原生 Toggle(.checkbox)，因为它与 Spacer 同处 HStack 时
+        // 其 AppKit 标题会被压成 0 宽而“消失”。
+        Button(action: toggle) {
+            HStack(spacing: 7) {
+                Image(systemName: isOn ? "checkmark.square.fill" : "square")
+                    .font(.system(size: Theme.fs(13)))
+                    .foregroundColor(isOn ? Theme.accent : Theme.placeholder)
+                Text(displayText)
+                    .font(.system(size: Theme.fs(12.5)))
+                    .foregroundColor(Theme.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 6)
+                if let shortcut = toggleActionInfo.shortcutsDisplayText {
+                    Keycap(text: shortcut)
+                        .opacity(isDisabled ? 0.4 : 1)
+                }
+            }
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.5 : 1)
+        #else
+        HStack(spacing: 6) {
             Toggle(isOn: Binding(
                 get: { toggleActionInfo.isOn() },
-                set: {
-                    ShortcutUsageStats.shared.recordFromButton(actionKey)
-                    toggleActionInfo.action($0)
-                }
+                set: { _ in toggle() }
             )) {
                 Text(displayText)
+                    .font(.system(size: Theme.fs(12.5)))
+                    .lineLimit(1)
             }
-            .disabled(!viewModel.isActionVisible(actionKey) || !toggleActionInfo.isEnabled())
-            Spacer()
+            .disabled(isDisabled)
+            Spacer(minLength: 6)
+            if let shortcut = toggleActionInfo.shortcutsDisplayText {
+                Keycap(text: shortcut)
+                    .opacity(isDisabled ? 0.4 : 1)
+            }
         }
+        .padding(.vertical, 3)
+        #endif
     }
-}   
+}
 
 #Preview {
     #if os(macOS)

--- a/XiangqiNotebook/Views/VariantListView.swift
+++ b/XiangqiNotebook/Views/VariantListView.swift
@@ -5,13 +5,10 @@ struct VariantListView: View {
     @ObservedObject var viewModel: ViewModel
     
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack() {
-                Text("本步变招")
-                Spacer()
-            }
-            if viewModel.currentGameVariantListDisplay.count > 1 {
-                ScrollView(showsIndicators: true) {
+        VStack(alignment: .leading, spacing: 5) {
+            GroupHeader("本步变招")
+            ScrollView(showsIndicators: true) {
+                if viewModel.currentGameVariantListDisplay.count > 1 {
                     VStack(alignment: .leading, spacing: 0) {
                         // 用 enumerated 的 offset 作为身份，与下方 scrollPosition
                         // 的 Int 索引保持同一身份类型，否则定位无法匹配
@@ -27,21 +24,23 @@ struct VariantListView: View {
                                     viewModel.playVariantMove(item.move)
                                 }
                             )
-                            Divider()
+                            Divider().overlay(Theme.hairline)
                         }
                     }
                     // scrollPosition(id:) 必须配套 scrollTargetLayout 才能定位条目
                     .scrollTargetLayout()
                 }
-                .scrollPosition(id: .constant(viewModel.currentGameVariantListDisplay.firstIndex(where: {
-                    $0.move.targetFenId == viewModel.currentFenId
-                })))
-                .opacity(viewModel.currentAppMode == .practice || (viewModel.currentAppMode == .review && !viewModel.showAllNextMoves) ? 0 : 1)
             }
-            Spacer()
+            .scrollPosition(id: .constant(viewModel.currentGameVariantListDisplay.firstIndex(where: {
+                $0.move.targetFenId == viewModel.currentFenId
+            })))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .insetBox()
+            .opacity(viewModel.currentAppMode == .practice || (viewModel.currentAppMode == .review && !viewModel.showAllNextMoves) ? 0 : 1)
         }
-        .padding()
-        .border(Color.gray)
+        // 两列（本步/下步变招）永远等宽等高，空的一侧也保留同样大小的框
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(6)
     }
 }
 
@@ -50,13 +49,10 @@ struct NextMovesListView: View {
     @ObservedObject var viewModel: ViewModel
 
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack() {
-                Text("下步变招")
-                Spacer()
-            }
-            if viewModel.currentNextMovesListDisplay.count > 1 {
-                ScrollView(showsIndicators: true) {
+        VStack(alignment: .leading, spacing: 5) {
+            GroupHeader("下步变招")
+            ScrollView(showsIndicators: true) {
+                if viewModel.currentNextMovesListDisplay.count > 1 {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(viewModel.currentNextMovesListDisplay, id: \.move) { item in
                             MoveItemView(
@@ -70,16 +66,17 @@ struct NextMovesListView: View {
                                     viewModel.playNextMove(item.move)
                                 }
                             )
-                            Divider()
+                            Divider().overlay(Theme.hairline)
                         }
                     }
                 }
-                .opacity(viewModel.currentAppMode == .practice || (viewModel.currentAppMode == .review && !viewModel.showAllNextMoves) ? 0 : 1)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .insetBox()
+            .opacity(viewModel.currentAppMode == .practice || (viewModel.currentAppMode == .review && !viewModel.showAllNextMoves) ? 0 : 1)
         }
-        .padding()
-        .border(Color.gray)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(6)
     }
 }
 
@@ -94,42 +91,55 @@ struct MoveItemView: View {
     let onTap: () -> Void
     
     var body: some View {
-        HStack {
-            Text(displayText)
-                .padding(.vertical, 2)
-                .padding(.horizontal, 4)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    Group {
-                        if isSelected {
-                            Color.blue.opacity(0.2)
-                        } else if isLocked {
-                            Color.gray.opacity(0.2)
-                        } else {
-                            Color.clear
-                        }
-                    }
-                )
+        HStack(spacing: 4) {
+            // 招法（变招列较窄，用半角数字更紧凑，优先保证招法完整不被截断）
+            Text(text)
+                .lineLimit(1)
+                .layoutPriority(1)
                 .foregroundColor(foregroundColor)
-                .contentShape(Rectangle())
-                .onTapGesture(perform: onTap)
+            Spacer(minLength: 4)
+            // 分数右对齐，按好坏着色
+            if !score.isEmpty {
+                Text(score)
+                    .monospacedDigit()
+                    .foregroundColor(scoreColor)
+            }
         }
+        .font(.system(size: Theme.fs(12.5)))
+        .padding(.vertical, 3)
+        .padding(.horizontal, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Group {
+                if isSelected {
+                    Theme.accent.opacity(0.12)
+                } else if isLocked {
+                    Color.black.opacity(0.05)
+                } else {
+                    Color.clear
+                }
+            }
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
     }
-    
-    private var displayText: String {
-        if !score.isEmpty {
-            return "\(text)（\(score)）"
-        }
-        return text
-    }
-    
+
     private var foregroundColor: Color {
         if isBadMove {
-            return .red
+            return Theme.bad
         } else if isRecommendedMove {
-            return .green
+            return Theme.good
         }
-        return .primary
+        return Theme.textPrimary
+    }
+
+    private var scoreColor: Color {
+        if isBadMove {
+            return Theme.bad
+        } else if isRecommendedMove {
+            return Theme.good
+        }
+        return Theme.textSecondary
     }
 }
 


### PR DESCRIPTION
## 概述
在**保持布局结构与棋盘渲染（`Views/board/`）不变**的前提下，对 macOS 主界面做整体视觉改版，并抽出集中的设计 tokens 作为单一调节点。

## 主要改动
- **新增 `DesignTokens.swift`**：集中管理配色、字号缩放（`fontScale = 1.15`，一处可调）、圆角、`Keycap`、`GroupHeader`、卡片/内嵌盒等设计原语。
- **各区域视觉重做**：状态栏合并三行卡片；底部工具栏渐变底 + 统一按钮样式；招法列表、本步/下步变招、评论区（相关课程 chip + 不好的原因红框）、书签、Toggle / 应用模式单选、侧栏（蓝色文件夹 + 战绩 chip + 折叠按钮）。
- **中列竖排**：改为「着法列表 / 本步变招 / 下步变招」上下排列，各占满列宽，修复窄窗口下变招分数被截断。
- **列宽稳定**：侧列 clamp 宽度 + `layoutPriority`，棋盘列弹性最低优先级，修复不同局面间列比例漂移。
- **底部按钮统一**：去掉「练习新局」主按钮蓝色高亮，避免被误读成激活态。

## Bug 修复
- `FlowLayout` 在无限宽提案下返回 `.infinity` 导致兄弟列塌陷。
- 状态栏统计项去掉 `.fixedSize()`，避免窄窗口下右栏消失。

## 测试
- macOS 单元测试 `XiangqiNotebookTests` ✅ TEST SUCCEEDED
- macOS 构建 ✅ / iOS 构建（pre-push 检查）✅
- 远程操控截图逐项视觉核对

🤖 Generated with [Claude Code](https://claude.com/claude-code)