### PR TITLE
本步/下步变招列表改为约 4 行固定高度，把纵向空间让给招法列表

### DIFF
--- a/XiangqiNotebook/Views/Mac/MacContentView.swift
+++ b/XiangqiNotebook/Views/Mac/MacContentView.swift
@@ -40,6 +40,12 @@ struct MacContentView: View {
             let middleWidth = clampWidth(totalWidth, ratio: 0.17, min: Theme.fs(208), max: Theme.fs(272))
             let rightWidth = clampWidth(totalWidth, ratio: 0.18, min: Theme.fs(220), max: Theme.fs(288))
 
+            // 本步 / 下步变招固定为约 4 行 item 的高度（多余交给滚动条），不再随窗口
+            // 高度线性增长挤占上方招法列表。各项随字号缩放，放大字体时同步变高。
+            //   行高 ≈ fs(20)（文字 fs 12.5 + 上下 padding 3 + 分隔线）
+            //   再加 标题 fs(12) + VStack spacing 5 + 外层上下 padding(6) 共 12
+            let variantListHeight = Theme.fs(20) * 4 + Theme.fs(12) + 5 + 12
+
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
                     // 棋局浏览器侧栏（弹性宽度 clamp(178, 15%, 238)，可折叠）
@@ -79,9 +85,9 @@ struct MacContentView: View {
                         MoveListView(viewModel: viewModel)
                             .frame(maxHeight: .infinity)
                         VariantListView(viewModel: viewModel)
-                            .frame(height: geometry.size.height * 0.18)
+                            .frame(height: variantListHeight)
                         NextMovesListView(viewModel: viewModel)
-                            .frame(height: geometry.size.height * 0.18)
+                            .frame(height: variantListHeight)
                     }
                     .frame(width: middleWidth)
                     .layoutPriority(1)


### PR DESCRIPTION
## 问题
本步变招 / 下步变招两个列表用 `geometry.size.height * 0.18` 定高，窗口越高它们越高，挤占上方招法列表能显示的行数。

## 改动
- 改为固定高度 `variantListHeight`（约 4 行 item + 标题 + 内外边距，随 `fontScale` 缩放），超出部分由内部已有的 `ScrollView` 滚动。
- 招法列表保持 `.frame(maxHeight: .infinity)`，自动吃掉腾出的纵向空间。

## 效果
- 本步变招正好显示 4 行，更多滚动查看。
- 下步变招项目少时全部显示。
- 招法列表可见行数明显增加。
- 放大字体时变招框同步变高，仍保持约 4 行。

## 测试
- macOS 构建 ✅ / 单元测试 `XiangqiNotebookTests` ✅ TEST SUCCEEDED / iOS 构建（pre-push）✅
- 远程截图确认：本步变招 4 行、下步变招全显、招法列表变高

🤖 Generated with [Claude Code](https://claude.com/claude-code)