### PR TITLE
修复 EvaluationQueueTests 的时序 flaky

### DIFF
--- a/XiangqiNotebookTests/EvaluationQueueTests.swift
+++ b/XiangqiNotebookTests/EvaluationQueueTests.swift
@@ -2,15 +2,48 @@
 import XCTest
 @testable import XiangqiNotebook
 
+/// 假引擎。
+///
+/// `evaluatePosition` 是非隔离的 async 方法，跑在通用执行器上，而队列的处理任务跑在
+/// MainActor 上——两个执行器读写同一批计数器，所以这里的可变状态一律上锁。
 class MockPikafishService: PikafishService {
+    /// 评估耗时。只用来模拟「要花点时间」，不承担让测试观察到中间态的职责
     var evaluateDelay: UInt64 = 10_000_000 // 10ms
     var resultToReturn: EvaluationResult? = EvaluationResult(
         score: 50, depth: "20", timeMs: 1000, hashfull: 500, timedOut: false, bestMove: "h2e2"
     )
-    var evaluateCallCount = 0
+
+    private let lock = NSLock()
+    private var _evaluateCallCount = 0
+    private var _holdEvaluation = false
+
+    var evaluateCallCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _evaluateCallCount
+    }
+
+    /// 置 true 时评估进入后一直挂着，直到测试置回 false（或任务被取消）。
+    ///
+    /// 「让请求停在评估中」必须是确定的。原先靠 `sleep(50ms)` 猜时机——赌它已经开始、
+    /// 又还没结束——并行跑测试时 CPU 一忙这个赌注就输：要么还没进评估，要么已经跑完，
+    /// 两头都会让断言莫名其妙地失败
+    var holdEvaluation: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _holdEvaluation }
+        set { lock.lock(); defer { lock.unlock() }; _holdEvaluation = newValue }
+    }
 
     override func evaluatePosition(fen: String, movetime: Int? = nil) async throws -> EvaluationResult? {
-        evaluateCallCount += 1
+        lock.lock()
+        _evaluateCallCount += 1
+        lock.unlock()
+
+        // 挂起期间照常让出执行器；被取消时 Task.sleep 抛错，连带把这里放出去。
+        // 加硬上限是兜底：某条断言失败提前返回时就没人来放行了，不封顶的话
+        // 这个任务会一直占着执行器，把之后每一个用例都拖慢
+        let deadline = Date().addingTimeInterval(10)
+        while holdEvaluation && Date() < deadline {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
         try await Task.sleep(nanoseconds: evaluateDelay)
         return resultToReturn
     }
@@ -20,6 +53,9 @@ class MockPikafishService: PikafishService {
     }
 }
 
+/// 队列状态由 MainActor 上的处理任务改写，测试也放到 MainActor 上读，
+/// 免得断言看到的是另一个执行器上的半成品
+@MainActor
 final class EvaluationQueueTests: XCTestCase {
 
     private func makeQueue(
@@ -32,11 +68,20 @@ final class EvaluationQueueTests: XCTestCase {
         return (queue, mockService)
     }
 
-    /// 轮询等待条件成立（替代固定 sleep，降低负载波动下的 flake）
-    private func waitUntil(timeout: TimeInterval = 3.0, _ condition: () -> Bool) async throws {
+    /// 轮询等待条件成立，替代固定 sleep。
+    ///
+    /// 超时直接报错并写明在等什么：不然只会看到后面某条断言「值不对」，
+    /// 分不清是没等到还是逻辑真的错了——这正是原先这几个用例难查的原因
+    private func waitUntil(_ what: String, timeout: TimeInterval = 5.0,
+                           file: StaticString = #filePath, line: UInt = #line,
+                           _ condition: () -> Bool) async throws {
         let start = Date()
-        while !condition() && Date().timeIntervalSince(start) < timeout {
-            try await Task.sleep(nanoseconds: 20_000_000)
+        while !condition() {
+            if Date().timeIntervalSince(start) >= timeout {
+                XCTFail("等待超时（\(timeout)s）：\(what)", file: file, line: line)
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
         }
     }
 
@@ -53,13 +98,11 @@ final class EvaluationQueueTests: XCTestCase {
         XCTAssertEqual(queue.state.totalEnqueued, 1)
         XCTAssertFalse(queue.state.isIdle)
 
-        // Wait for processing
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitUntil("队列跑完") { queue.state.isIdle }
 
         XCTAssertEqual(completedRequests.count, 1)
         XCTAssertEqual(completedRequests.first?.fenId, 1)
         XCTAssertEqual(mock.evaluateCallCount, 1)
-        XCTAssertTrue(queue.state.isIdle)
         XCTAssertEqual(queue.state.completedCount, 1)
     }
 
@@ -73,14 +116,13 @@ final class EvaluationQueueTests: XCTestCase {
 
         XCTAssertEqual(queue.state.totalEnqueued, 1)
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitUntil("队列跑完") { queue.state.isIdle }
 
         XCTAssertEqual(mock.evaluateCallCount, 1)
     }
 
     func testDifferentEngineKeysNotDeduplicated() async throws {
         let (queue, mock) = makeQueue()
-        mock.evaluateDelay = 5_000_000
 
         let req1 = EvaluationRequest(fenId: 1, fen: "test r", engineKey: "deep", movetime: nil)
         let req2 = EvaluationRequest(fenId: 1, fen: "test r", engineKey: "quick", movetime: 3000)
@@ -89,7 +131,7 @@ final class EvaluationQueueTests: XCTestCase {
 
         XCTAssertEqual(queue.state.totalEnqueued, 2)
 
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await waitUntil("两条都跑完") { queue.state.isIdle }
 
         XCTAssertEqual(mock.evaluateCallCount, 2)
     }
@@ -100,23 +142,22 @@ final class EvaluationQueueTests: XCTestCase {
         let request = EvaluationRequest(fenId: 1, fen: "test r", engineKey: "testKey", movetime: nil)
         queue.enqueue(request)
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitUntil("队列跑完") { queue.state.isIdle }
 
         XCTAssertEqual(mock.evaluateCallCount, 0)
         XCTAssertEqual(queue.state.completedCount, 1)
-        XCTAssertTrue(queue.state.isIdle)
     }
 
     func testCancelAll() async throws {
         let mock = MockPikafishService()
-        mock.evaluateDelay = 500_000_000 // 500ms per evaluation
+        mock.holdEvaluation = true
         let (queue, _) = makeQueue(mockService: mock)
 
         for i in 0..<5 {
             queue.enqueue(EvaluationRequest(fenId: i, fen: "fen\(i) r", engineKey: "key", movetime: nil))
         }
 
-        try await Task.sleep(nanoseconds: 50_000_000)
+        try await waitUntil("第一条进入评估中") { mock.evaluateCallCount == 1 }
 
         queue.cancelAll()
 
@@ -124,25 +165,29 @@ final class EvaluationQueueTests: XCTestCase {
         XCTAssertEqual(queue.state.totalEnqueued, 0)
         XCTAssertEqual(queue.state.pendingCount, 0)
 
-        // 在飞的旧任务退出前队列不算 idle（防止并发驱动引擎）；
-        // 退出后转为 idle
-        try await waitUntil { queue.isIdle }
-        XCTAssertTrue(queue.isIdle)
+        // cancelAll 是同步的，这中间没有 await，在飞的旧任务不可能已经退出。
+        // 此刻若判为 idle，紧接着的 enqueue 就会另起一个处理任务，
+        // 与旧任务并发驱动同一个无锁的 PikafishService
+        XCTAssertFalse(queue.isIdle, "在飞的旧任务退出前不得转 idle")
+
+        mock.holdEvaluation = false
+        try await waitUntil("旧任务退出后转 idle") { queue.isIdle }
     }
 
     func testCancelAllThenReenqueue_ProcessesWithoutStatePollution() async throws {
         let mock = MockPikafishService()
-        mock.evaluateDelay = 200_000_000 // 200ms
+        mock.holdEvaluation = true
         let (queue, _) = makeQueue(mockService: mock)
 
         queue.enqueue(EvaluationRequest(fenId: 1, fen: "fen1 r", engineKey: "key", movetime: nil))
-        try await Task.sleep(nanoseconds: 50_000_000) // 让请求进入评估中
+        try await waitUntil("请求进入评估中") { mock.evaluateCallCount == 1 }
 
         queue.cancelAll()
         // 旧任务还在退出途中时立即重新入队同一局面
         queue.enqueue(EvaluationRequest(fenId: 1, fen: "fen1 r", engineKey: "key", movetime: nil))
+        mock.holdEvaluation = false
 
-        try await waitUntil { queue.state.isIdle && queue.state.completedCount == 1 }
+        try await waitUntil("新请求跑完") { queue.state.isIdle && queue.state.completedCount == 1 }
 
         // 新请求被处理恰好一次；旧任务的收尾不得污染新队列的去重与状态
         XCTAssertEqual(queue.state.completedCount, 1)
@@ -152,7 +197,7 @@ final class EvaluationQueueTests: XCTestCase {
 
     func testStatusForFen() async throws {
         let mock = MockPikafishService()
-        mock.evaluateDelay = 200_000_000 // 200ms
+        mock.holdEvaluation = true
         let (queue, _) = makeQueue(mockService: mock)
 
         XCTAssertEqual(queue.statusForFen(fenId: 1, engineKey: "key"), .idle)
@@ -160,18 +205,19 @@ final class EvaluationQueueTests: XCTestCase {
         queue.enqueue(EvaluationRequest(fenId: 1, fen: "fen1 r", engineKey: "key", movetime: nil))
         queue.enqueue(EvaluationRequest(fenId: 2, fen: "fen2 r", engineKey: "key", movetime: nil))
 
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // currentRequest 在调用引擎之前就已写好，所以计数一到 1，1 号必然是「评估中」
+        try await waitUntil("1 号进入评估中") { mock.evaluateCallCount == 1 }
 
         XCTAssertEqual(queue.statusForFen(fenId: 1, engineKey: "key"), .evaluating)
         XCTAssertEqual(queue.statusForFen(fenId: 2, engineKey: "key"), .queued)
         XCTAssertEqual(queue.statusForFen(fenId: 3, engineKey: "key"), .idle)
 
+        mock.holdEvaluation = false
         queue.cancelAll()
     }
 
     func testEnqueueAll() async throws {
         let (queue, mock) = makeQueue()
-        mock.evaluateDelay = 5_000_000
 
         let requests = (0..<3).map { i in
             EvaluationRequest(fenId: i, fen: "fen\(i) r", engineKey: "key", movetime: nil)
@@ -180,11 +226,10 @@ final class EvaluationQueueTests: XCTestCase {
 
         XCTAssertEqual(queue.state.totalEnqueued, 3)
 
-        try await Task.sleep(nanoseconds: 300_000_000)
+        try await waitUntil("三条都跑完") { queue.state.isIdle }
 
         XCTAssertEqual(mock.evaluateCallCount, 3)
         XCTAssertEqual(queue.state.completedCount, 3)
-        XCTAssertTrue(queue.state.isIdle)
     }
 
     func testCompletionState() async throws {
@@ -193,10 +238,9 @@ final class EvaluationQueueTests: XCTestCase {
         let request = EvaluationRequest(fenId: 1, fen: "test r", engineKey: "key", movetime: nil)
         queue.enqueue(request)
 
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await waitUntil("队列跑完") { queue.state.isCompleted }
 
         XCTAssertTrue(queue.state.isIdle)
-        XCTAssertTrue(queue.state.isCompleted)
         XCTAssertEqual(queue.state.completedCount, 1)
         XCTAssertEqual(queue.state.totalEnqueued, 1)
     }


### PR DESCRIPTION
## 问题

`EvaluationQueueTests` 里几个用例靠 `Task.sleep(50ms)` 让请求进入「评估中」，再断言这个中间态。并行跑测试时 CPU 一忙这个赌注就输——要么还没进评估，要么已经跑完，两头都让断言莫名其妙地失败。

典型表现是**全量跑失败、单跑必过**，而且失败的用例还会飘（`testCancelAll` / `testCancelAllThenReenqueue` / `testStatusForFen` 轮流中招）。

## 改法

核心是把「停在评估中」从**猜时机**变成**确定状态**：

- `MockPikafishService` 新增 `holdEvaluation`，置 true 时评估进入后一直挂着，测试想让它停多久就停多久。带 10 秒硬上限兜底——断言提前失败时没人来放行，不封顶的话那个任务会一直占着执行器，把之后每个用例都拖慢
- 所有固定 sleep 换成 `waitUntil`，超时直接报错并写明在等什么（原来只会看到后面某条断言「值不对」，分不清是没等到还是逻辑真错了）
- 计数器与 `holdEvaluation` 上锁：`evaluatePosition` 是非隔离 async，跑在通用执行器上，而队列处理跑在 MainActor
- 测试类标 `@MainActor`，与改写队列状态的处理任务同处一个执行器

## 顺带补上一条断言

`testCancelAll` 原本只在注释里写了「在飞的旧任务退出前队列不算 idle」，没有断言。现在 `holdEvaluation` 让这个时刻变得确定，就把它钉住了：

```swift
XCTAssertFalse(queue.isIdle, "在飞的旧任务退出前不得转 idle")
```

这条对应 `EvaluationQueue.cancelAll()` 里那段注释——此刻若判为 idle，紧接着的 `enqueue` 会另起一个处理任务，与旧任务**并发驱动同一个无锁的 PikafishService**。

## 验证

- 全量单测连跑三次全绿
- 九条用例每条都在 0.05 秒内（原来动辄几秒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
